### PR TITLE
Mount docker postgres volume on host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
 
   postgres:
     image: postgres:9.5
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data
 
   web:
     extends: base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       SENTRY_POSTGRES_HOST: postgres
       SENTRY_EMAIL_HOST: smtp
     volumes:
-      - ./data:/var/lib/sentry/files
+      - ./data/sentry:/var/lib/sentry/files
 
   smtp:
     image: tianon/exim4


### PR DESCRIPTION
I think this should be part of the default settings. Otherwise, taking sentry down with
```
docker-compose down
```
means we just lost all the data in postgres, including users data and events gathered so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/onpremise/4)
<!-- Reviewable:end -->
