### PR TITLE
Add Up and Running instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Official bootstrap for running your own [Sentry](https://getsentry.com/) with [D
  * Docker 1.10.0+
  * Compose 1.6.0+ _(optional)_
 
+## Up and Running
+
+The following steps will get you up and running in no time!
+
+1. `docker-compose run web sentry config generate-secret-key` - Generate a
+   secret key unique to your deployment.
+2. Edit `docker-compose.yml` inserting the key via `SENTRY_SECRET_KEY`
+3. `docker-compose run web upgrade` Prime the Database!
+4. `docker-compose up -d` Launch!
+
 ## Resources
 
  * [Documentation](https://docs.getsentry.com/on-premise/server/installation/docker/)


### PR DESCRIPTION
It's not exactly well documented that you need to generate a secret key and prime the database before you can just `docker-compose up -d`. I've added a quick up and running section to the readme to help people out!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/onpremise/6)
<!-- Reviewable:end -->
