### PR TITLE
Updates to docker compose setup

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  sentry_base:
+    build: .
+    environment:
+      # Run `docker-compose run web config generate-secret-key`
+      # to get the SENTRY_SECRET_KEY value.
+      # SENTRY_SECRET_KEY: ''
+      SENTRY_MEMCACHED_HOST: memcached
+      SENTRY_REDIS_HOST: redis
+      SENTRY_POSTGRES_HOST: postgres
+      SENTRY_EMAIL_HOST: smtp
+    volumes:
+      - ./data/sentry:/var/lib/sentry/files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,12 @@ services:
       - ./data/sentry:/var/lib/sentry/files
     ports:
       - '9000:9000'
-    links: &sentry_links
+    links:
       - redis
       - postgres
       - memcached
       - smtp
-    depends_on: &sentry_depends
+    depends_on:
       - redis
       - postgres
       - memcached
@@ -32,15 +32,31 @@ services:
     extends: web
     command: run cron
     ports: []
-    links: *sentry_links
-    depends_on: *sentry_depends
+    links:
+      - redis
+      - postgres
+      - memcached
+      - smtp
+    depends_on:
+      - redis
+      - postgres
+      - memcached
+      - smtp
 
   worker:
     extends: web
     command: run worker
     ports: []
-    links: *sentry_links
-    depends_on: *sentry_depends
+    links:
+      - redis
+      - postgres
+      - memcached
+      - smtp
+    depends_on:
+      - redis
+      - postgres
+      - memcached
+      - smtp
 
   smtp:
     image: tianon/exim4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,17 +4,9 @@
 version: '2'
 services:
   web:
-    build: .
-    environment:
-      # Run `docker-compose run web config generate-secret-key`
-      # to get the SENTRY_SECRET_KEY value.
-      # SENTRY_SECRET_KEY: ''
-      SENTRY_MEMCACHED_HOST: memcached
-      SENTRY_REDIS_HOST: redis
-      SENTRY_POSTGRES_HOST: postgres
-      SENTRY_EMAIL_HOST: smtp
-    volumes:
-      - ./data/sentry:/var/lib/sentry/files
+    extends:
+      service: sentry_base
+      file: docker-compose-base.yml
     ports:
       - '9000:9000'
     links:
@@ -29,7 +21,9 @@ services:
       - smtp
 
   cron:
-    extends: web
+    extends:
+      service: sentry_base
+      file: docker-compose-base.yml
     command: run cron
     ports: []
     links:
@@ -44,7 +38,9 @@ services:
       - smtp
 
   worker:
-    extends: web
+    extends:
+      service: sentry_base
+      file: docker-compose-base.yml
     command: run worker
     ports: []
     links:
@@ -71,3 +67,4 @@ services:
     image: postgres:9.5
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,12 @@ services:
       file: docker-compose-base.yml
     ports:
       - '9000:9000'
-    links:
+    links: &sentry_links
       - redis
       - postgres
       - memcached
       - smtp
-    depends_on:
+    depends_on: &sentry_depends
       - redis
       - postgres
       - memcached
@@ -26,16 +26,8 @@ services:
       file: docker-compose-base.yml
     command: run cron
     ports: []
-    links:
-      - redis
-      - postgres
-      - memcached
-      - smtp
-    depends_on:
-      - redis
-      - postgres
-      - memcached
-      - smtp
+    links: *sentry_links
+    depends_on: *sentry_depends
 
   worker:
     extends:
@@ -43,16 +35,8 @@ services:
       file: docker-compose-base.yml
     command: run worker
     ports: []
-    links:
-      - redis
-      - postgres
-      - memcached
-      - smtp
-    depends_on:
-      - redis
-      - postgres
-      - memcached
-      - smtp
+    links: *sentry_links
+    depends_on: *sentry_depends
 
   smtp:
     image: tianon/exim4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 
 version: '2'
 services:
-  base:
+  web:
     build: .
     environment:
       # Run `docker-compose run web config generate-secret-key`
@@ -15,6 +15,32 @@ services:
       SENTRY_EMAIL_HOST: smtp
     volumes:
       - ./data/sentry:/var/lib/sentry/files
+    ports:
+      - '9000:9000'
+    links: &sentry_links
+      - redis
+      - postgres
+      - memcached
+      - smtp
+    depends_on: &sentry_depends
+      - redis
+      - postgres
+      - memcached
+      - smtp
+
+  cron:
+    extends: web
+    command: run cron
+    ports: []
+    links: *sentry_links
+    depends_on: *sentry_depends
+
+  worker:
+    extends: web
+    command: run worker
+    ports: []
+    links: *sentry_links
+    depends_on: *sentry_depends
 
   smtp:
     image: tianon/exim4
@@ -29,31 +55,3 @@ services:
     image: postgres:9.5
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
-
-  web:
-    extends: base
-    links:
-      - redis
-      - postgres
-      - memcached
-      - smtp
-    ports:
-      - '9000:9000'
-
-  cron:
-    extends: base
-    command: run cron
-    links:
-      - redis
-      - postgres
-      - memcached
-      - smtp
-
-  worker:
-    extends: base
-    command: run worker
-    links:
-      - redis
-      - postgres
-      - memcached
-      - smtp


### PR DESCRIPTION
This removes the base, as the previouse setup run both base + web, which led to running the web service twice.

It uses depends_on and links as references on the worker and cron, since they are the same for web, worker and cron.
