### PR TITLE
Upgrade to use sentry 8.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM sentry:8.9-onbuild
+FROM sentry:8.10-onbuild


### PR DESCRIPTION
8.10 was released on 2016-11-01