### PR TITLE
Add note to README to escape $ chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ There may need to be modifications to the included `docker-compose.yml` file to 
 1. `mkdir -p data/{sentry,postgres}` - Make our local database and sentry config directories.
     This directory is bind-mounted with postgres so you don't lose state!
 2. `docker-compose run --rm web config generate-secret-key` - Generate a secret key.
-    Add it to `docker-compose.yml` in `base` as `SENTRY_SECRET_KEY`.
+    Add it to `docker-compose.yml` in `base` as `SENTRY_SECRET_KEY`. If you get **Invalid interpolation format** error
+    remember to escape $ in the key with $$.
 3. `docker-compose run --rm web upgrade` - Build the database.
     Use the interactive prompts to create a user account.
 4. `docker-compose up -d` - Lift all services (detached/background mode).


### PR DESCRIPTION
When using latest docker-compose I've got "Invalid interpolation format" because the secret key I added to docker-compose.yml had $. It was not obvious what was the problem.