### PR TITLE
Use 8.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM sentry:8.16-onbuild
+FROM sentry:8.17-onbuild


### PR DESCRIPTION
Sentry 8.17 has released, bump onpremise to 8.17 as well.