### PR TITLE
Switch from "links" to "depends_on" in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   web:
     restart: unless-stopped
     extends: base
-    links:
+    depends_on:
       - redis
       - postgres
       - memcached
@@ -55,7 +55,7 @@ services:
     restart: unless-stopped
     extends: base
     command: run cron
-    links:
+    depends_on:
       - redis
       - postgres
       - memcached
@@ -65,7 +65,7 @@ services:
     restart: unless-stopped
     extends: base
     command: run worker
-    links:
+    depends_on:
       - redis
       - postgres
       - memcached


### PR DESCRIPTION
Now in Docker all containers can reach each other while they are in the same network. docker-compose transparently creates default network. Also `links` functionality is deprecated. In order to not break starting order of services we need to replace links with `depends_on`.