### PR TITLE
Add docker-compose build to the Up and Running steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ There may need to be modifications to the included `docker-compose.yml` file to 
 
 1. `mkdir -p data/{sentry,postgres}` - Make our local database and sentry config directories.
     This directory is bind-mounted with postgres so you don't lose state!
-2. `docker-compose run --rm web config generate-secret-key` - Generate a secret key.
+1. `docker-compose build` - Build and tag the Docker services.
+1. `docker-compose run --rm web config generate-secret-key` - Generate a secret key.
     Add it to `docker-compose.yml` in `base` as `SENTRY_SECRET_KEY`.
-3. `docker-compose run --rm web upgrade` - Build the database.
+1. `docker-compose run --rm web upgrade` - Build the database.
     Use the interactive prompts to create a user account.
-4. `docker-compose up -d` - Lift all services (detached/background mode).
-5. Access your instance at `localhost:9000`!
+1. `docker-compose up -d` - Lift all services (detached/background mode).
+1. Access your instance at `localhost:9000`!
 
 Note that as long as you have your database bind-mounted, you should
 be fine stopping and removing the containers without worry.


### PR DESCRIPTION
This step was necessary to prevent the following error:

```
Pulling smtp (tianon/exim4:latest)...
ERROR: manifest for tianon/exim4:latest not found
```

Also changed the numbered list to use [lazy numbering](https://daringfireball.net/projects/markdown/syntax#list)