### PR TITLE
Docker compose 3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ If you'd like to protect your Sentry install with SSL/TLS, there are
 fantastic SSL/TLS proxies like [HAProxy](http://www.haproxy.org/)
 and [Nginx](http://nginx.org/).
 
+## Updating Sentry
+
+Updating Sentry using Compose is relativally simple. Just use the following steps to update. Make sure that you have the latest version set in your Dockerfile. Or use the latest version of this repository.
+
+Use the following steps after updating this repository or your Dockerfile:
+```sh
+docker-compose build # Build the services again after updating
+docker-compose run --rm web upgrade # Run new migrations
+docker-compose up -d # Recreate the services
+```
+
 ## Resources
 
  * [Documentation](https://docs.sentry.io/server/installation/docker/)

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ There may need to be modifications to the included `docker-compose.yml` file to 
 
 1. `mkdir -p data/{sentry,postgres}` - Make our local database and sentry config directories.
     This directory is bind-mounted with postgres so you don't lose state!
-2. `docker-compose run --rm web config generate-secret-key` - Generate a secret key.
+2. `docker-compose build` - Build and tag the Docker services
+3. `docker-compose run --rm web config generate-secret-key` - Generate a secret key.
     Add it to `docker-compose.yml` in `base` as `SENTRY_SECRET_KEY`.
-3. `docker-compose run --rm web upgrade` - Build the database.
+4. `docker-compose run --rm web upgrade` - Build the database.
     Use the interactive prompts to create a user account.
-4. `docker-compose up -d` - Lift all services (detached/background mode).
-5. Access your instance at `localhost:9000`!
+5. `docker-compose up -d` - Lift all services (detached/background mode).
+6. Access your instance at `localhost:9000`!
 
 Note that as long as you have your database bind-mounted, you should
 be fine stopping and removing the containers without worry.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,22 +6,30 @@
 # See docs.getsentry.com/on-premise/server/ for full
 # instructions
 
-version: '2'
-services:
-  base:
-    restart: unless-stopped
-    build: .
-    environment:
-      # Run `docker-compose run web config generate-secret-key`
-      # to get the SENTRY_SECRET_KEY value.
-      # SENTRY_SECRET_KEY: ''
-      SENTRY_MEMCACHED_HOST: memcached
-      SENTRY_REDIS_HOST: redis
-      SENTRY_POSTGRES_HOST: postgres
-      SENTRY_EMAIL_HOST: smtp
-    volumes:
-      - ./data/sentry:/var/lib/sentry/files
+version: '3.4'
 
+x-defaults: &defaults
+  restart: unless-stopped
+  build: .
+  depends_on:
+    - redis
+    - postgres
+    - memcached
+    - smtp
+
+  environment:
+    # Run `docker-compose run web config generate-secret-key`
+    # to get the SENTRY_SECRET_KEY value.
+    SENTRY_SECRET_KEY: ''
+    SENTRY_MEMCACHED_HOST: memcached
+    SENTRY_REDIS_HOST: redis
+    SENTRY_POSTGRES_HOST: postgres
+    SENTRY_EMAIL_HOST: smtp
+  volumes:
+    - sentry-data:/var/lib/sentry/files
+
+
+services:
   smtp:
     restart: unless-stopped
     image: tianon/exim4
@@ -38,35 +46,22 @@ services:
     restart: unless-stopped
     image: postgres:9.5
     volumes:
-      - ./data/postgres:/var/lib/postgresql/data
+      - sentry-postgres:/var/lib/postgresql/data
 
   web:
-    restart: unless-stopped
-    extends: base
-    links:
-      - redis
-      - postgres
-      - memcached
-      - smtp
+    <<: *defaults
     ports:
       - '9000:9000'
 
   cron:
-    restart: unless-stopped
-    extends: base
+    <<: *defaults
     command: run cron
-    links:
-      - redis
-      - postgres
-      - memcached
-      - smtp
 
   worker:
-    restart: unless-stopped
-    extends: base
+    <<: *defaults
     command: run worker
-    links:
-      - redis
-      - postgres
-      - memcached
-      - smtp
+
+
+volumes:
+    sentry-data:
+    sentry-postgres:


### PR DESCRIPTION
 - upgrade docker compose to 3.4
      - use `depends_on`
      - reuse a `default`  block
      - use docker named volumes

and some readme fixes