### PR TITLE
Improve setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Run `docker-compose run web config generate-secret-key`
+# to get the SENTRY_SECRET_KEY value.
+SENTRY_SECRET_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ target/
 # pyenv
 .python-version
 
+# https://docs.docker.com/compose/extends/
+docker-compose.override.yml
+
 # env config
 .env
 

--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,8 @@ target/
 # pyenv
 .python-version
 
+# env config
+.env
+
 *.tar
 data/

--- a/README.md
+++ b/README.md
@@ -14,18 +14,15 @@ will get you up and running in no time!
 
 There may need to be modifications to the included `docker-compose.yml` file to accommodate your needs or your environment. These instructions are a guideline for what you should generally do.
 
-1. `mkdir -p data/{sentry,postgres}` - Make our local database and sentry config directories.
-    This directory is bind-mounted with postgres so you don't lose state!
 2. `docker-compose build` - Build and tag the Docker services
 3. `docker-compose run --rm web config generate-secret-key` - Generate a secret key.
     Add it to `docker-compose.yml` in `base` as `SENTRY_SECRET_KEY`.
 4. `docker-compose run --rm web upgrade` - Build the database.
+1. `docker volume create --name=sentry-data && docker volume create --name=sentry-postgres` - Make our local database and sentry volumes
+    Docker volumes have to be created manually, as they are declared as external to be more durable.
     Use the interactive prompts to create a user account.
 5. `docker-compose up -d` - Lift all services (detached/background mode).
 6. Access your instance at `localhost:9000`!
-
-Note that as long as you have your database bind-mounted, you should
-be fine stopping and removing the containers without worry.
 
 ## Securing Sentry with SSL/TLS
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ will get you up and running in no time!
 
 There may need to be modifications to the included `docker-compose.yml` file to accommodate your needs or your environment. These instructions are a guideline for what you should generally do.
 
-2. `docker-compose build` - Build and tag the Docker services
-3. `docker-compose run --rm web config generate-secret-key` - Generate a secret key.
-    Add it to `docker-compose.yml` in `base` as `SENTRY_SECRET_KEY`.
-4. `docker-compose run --rm web upgrade` - Build the database.
 1. `docker volume create --name=sentry-data && docker volume create --name=sentry-postgres` - Make our local database and sentry volumes
     Docker volumes have to be created manually, as they are declared as external to be more durable.
+2. `cp -n .env.example .env` - create env config file
+3. `docker-compose build` - Build and tag the Docker services
+4. `docker-compose run --rm web config generate-secret-key` - Generate a secret key.
+    Add it to `.env` as `SENTRY_SECRET_KEY`.
+5. `docker-compose run --rm web upgrade` - Build the database.
     Use the interactive prompts to create a user account.
-5. `docker-compose up -d` - Lift all services (detached/background mode).
-6. Access your instance at `localhost:9000`!
+6. `docker-compose up -d` - Lift all services (detached/background mode).
+7. Access your instance at `localhost:9000`!
 
 ## Securing Sentry with SSL/TLS
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,4 +64,6 @@ services:
 
 volumes:
     sentry-data:
+      external: true
     sentry-postgres:
+      external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,8 @@ x-defaults: &defaults
     - postgres
     - memcached
     - smtp
-
+  env_file: .env
   environment:
-    # Run `docker-compose run web config generate-secret-key`
-    # to get the SENTRY_SECRET_KEY value.
-    SENTRY_SECRET_KEY: ''
     SENTRY_MEMCACHED_HOST: memcached
     SENTRY_REDIS_HOST: redis
     SENTRY_POSTGRES_HOST: postgres


### PR DESCRIPTION
This pull request improves upon #105 ( and follows for rejected #115 )

 - removed from readme all references for bind mounting storage ( replaced with docker volumes in #105 )
 - volumes are now declared as external, to make them more durable ( regular volumes will be deleted when you, for example, run `docker-compose down -v`)
 - moved `SENTRY_SECRET_KEY` to .env file that is not part of git repo (so setup from here can be used  directly)
 - added `docker-compose.override.yml` to .gitignore file ( so base setup can be extended, I, for example, used that to add a label to web container to get traefik routing for https )
