### PR TITLE
Add Minimum Hardware Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docke
  
  * 1GHz CPU
  * 3GB Ram
- * 5GB Hard drive
+
 
 
 ## Up and Running

--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docke
  
  ## Minimum Hardware Requirements:
  
- * 1GHz CPU
- * 3GB Ram
-
-
+ * You need at least 3GB Ram
 
 ## Up and Running
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docke
 
  * Docker 1.10.0+
  * Compose 1.6.0+ _(optional)_
+ 
+ ## Minimum Hardware Requirements:
+ 
+ * 1GHz CPU
+ * 3GB Ram
+ * 5GB Hard drive
+
 
 ## Up and Running
 


### PR DESCRIPTION
Because for less hardware requirements, will give migration and create default user errors: #114, #49, #147