### PR TITLE
Fix possible typo in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 .hypothesis/
 
 # Translations


### PR DESCRIPTION
Remove a match-all glob pattern. It looks like some non-git tools read the `*,cover` as `*` and `cover` separately and basically ignore all files. Even though this is not really a problem with the repo itself, I think the change is still valid, considering `*,cover` looks like an invalid rule anyway.


_____

Background:

(__This part is vim-specific__)

For a while now, my Neosnippet configuration has been going for a toss when working on our fork based off of this repo. I see a message similar to the one reported [here](https://github.com/Shougo/neocomplcache.vim/issues/468), but my vimrc configuration is as per the documentation available in the plugin docs. I finally spent enough time to debug this today, and it turns out this issue was happening *only* in this repo and nowhere else. So I went through the files that might've to do anything with folder-specific configuration (think dotenv, editorconfig etc.), and turned out `.gitignore` was the only such file; I use [this plugin](https://github.com/vim-scripts/gitignore) to load the gitignore rules into the `wildignore` completion and the `*,` part basically (from what I understand) removes most of the load path configuration from vim 😄. I'll probably have to go make a change in that plugin as well though.