### PR TITLE
fix(config): Remove autocommit option from DB config

### DIFF
--- a/sentry.conf.py
+++ b/sentry.conf.py
@@ -83,9 +83,6 @@ if postgres:
                 env('SENTRY_POSTGRES_PORT')
                 or ''
             ),
-            'OPTIONS': {
-                'autocommit': True,
-            },
         },
     }
 


### PR DESCRIPTION
Django 1.6 already defaults to `True` for this and in Django 1.8, which
is what the latest Sentry uses, the option is removed and causes a DB
connection error so dropping it to fix git builds.

See https://stackoverflow.com/a/29444039/90297.