### PR TITLE
Dockerfile & Makefile argument name mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ NO_COLOR=\033[0m
 
 build:
 	@printf "$(OK_COLOR)==>$(NO_COLOR) Building $(REPOSITORY):$(TAG)\n"
-	@docker build --pull --rm -t $(REPOSITORY):$(TAG) . --build-arg IMAGE=sentry:9.1
+	@docker build --pull --rm -t $(REPOSITORY):$(TAG) . --build-arg SENTRY_IMAGE=sentry:9.1
 
 $(REPOSITORY)_$(TAG).tar: build
 	@printf "$(OK_COLOR)==>$(NO_COLOR) Saving $(REPOSITORY):$(TAG) > $@\n"


### PR DESCRIPTION
Dockerfile expects the argument to be `SENTRY_IMAGE`. So, modifying Makefile to enable `make build`