### PR TITLE
Give error message if environment variable SENTRY_IMAGE is not set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-defaults: &defaults
   build:
     context: .
     args:
-      SENTRY_IMAGE: ${SENTRY_IMAGE}
+      SENTRY_IMAGE: ${SENTRY_IMAGE:?err}
   depends_on:
     - redis
     - postgres


### PR DESCRIPTION
If SENTRY_IMAGE is not set docker-compose will just give a warning and default to a blank string and continue.
