### PR TITLE
Declare ARG in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,2 @@
+ARG SENTRY_IMAGE
 FROM ${SENTRY_IMAGE:-sentry:9.1.2}-onbuild


### PR DESCRIPTION
Resolves [Warning] One or more build-args [SENTRY_IMAGE] were not consumed.