### PR TITLE
fix(kafka): Disable support metrics in Kafka & ZK

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,8 +65,9 @@ services:
     image: 'confluentinc/cp-zookeeper:5.1.2'
     environment:
       ZOOKEEPER_CLIENT_PORT: '2181'
-      ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: 'ERROR'
-      ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: 'ERROR'
+      CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
+      ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: 'WARN'
+      ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: 'WARN'
     volumes:
       - 'sentry-zookeeper:/var/lib/zookeeper'
   kafka:
@@ -78,9 +79,10 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1'
+      CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
       KAFKA_LOG4J_LOGGERS: 'kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,kafka.zookeeper=WARN,state.change.logger=WARN'
-      KAFKA_LOG4J_ROOT_LOGLEVEL: 'ERROR'
-      KAFKA_TOOLS_LOG4J_LOGLEVEL: 'ERROR'
+      KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'
+      KAFKA_TOOLS_LOG4J_LOGLEVEL: 'WARN'
     volumes:
       - 'sentry-kafka:/var/lib/kafka'
   clickhouse:


### PR DESCRIPTION
Disables the annoying automatic support metrics for Kafka and ZK while defaulting all logs to WARN level, instead of some being WARN and some ERROR.