### PR TITLE
fix(data): Use `/data` for persisting files and file caches

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,7 @@ x-sentry-defaults: &sentry_defaults
   environment:
     SNUBA: 'http://snuba-api:1218'
   volumes:
-    - 'sentry-data:/var/lib/sentry/files'
-  tmpfs:
-    - '/tmp'
+    - 'sentry-data:/data'
 x-snuba-defaults: &snuba_defaults
   << : *restart_policy
   depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ x-sentry-defaults: &sentry_defaults
     SNUBA: 'http://snuba-api:1218'
   volumes:
     - 'sentry-data:/var/lib/sentry/files'
+  tmpfs:
+    - '/tmp'
 x-snuba-defaults: &snuba_defaults
   << : *restart_policy
   depends_on:

--- a/install.sh
+++ b/install.sh
@@ -130,6 +130,10 @@ until $(docker-compose run --rm clickhouse clickhouse-client -h clickhouse --que
 done;
 echo ""
 
+echo "Migrating file storage..."
+docker run --rm -it -v sentry-data:/data alpine ash -c \
+  "mkdir -p /tmp/files; mv /data/* /tmp/files/; mv /tmp/files /data/files"
+
 cleanup
 
 echo ""

--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -55,7 +55,9 @@ system.secret-key: '!!changeme!!'
 
 filestore.backend: 'filesystem'
 filestore.options:
-  location: '/var/lib/sentry/files'
+  location: '/data/files'
+dsym.cache-path: '/data/dsym-cache'
+releasefile.cache-path: '/data/releasefile-cache'
 
 # filestore.backend: 's3'
 # filestore.options:


### PR DESCRIPTION
Moves `sentry-data` volume to `/data` mount point and sets all file-based storage settings to `/data/files`, `/data/dsym-cache` etc. accordingly. See https://github.com/getsentry/sentry/blob/50ac5506669043dd939dd0e44fe4cfb00377ff1d/src/sentry/options/defaults.py#L45-L54