### PR TITLE
fix(post-process): Add missing post-process-forwarder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,8 @@ services:
     command: run worker
   post-process-forwarder:
     << : *sentry_defaults
-    command: run post-process-forwarder --commit-batch-size 3
+    # Increase `--commit-batch-size 1` below to deal with high-load environments.
+    command: run post-process-forwarder --commit-batch-size 1
   sentry-cleanup:
     << : *sentry_defaults
     image: sentry-cleanup-onpremise-local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,9 @@ services:
   worker:
     << : *sentry_defaults
     command: run worker
+  post-process-forwarder:
+    << : *sentry_defaults
+    command: run post-process-forwarder --commit-batch-size 3
   sentry-cleanup:
     << : *sentry_defaults
     image: sentry-cleanup-onpremise-local


### PR DESCRIPTION
We were not running the post-process forwarder, causing post-process to not run which covers all plugin and rule/alert work.

Fixes #287.