### PR TITLE
Add configurable SENTRY_WEB_EXPOSED_PORT env variable in stable release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Run `docker-compose run web config generate-secret-key`
 # to get the SENTRY_SECRET_KEY value.
 SENTRY_SECRET_KEY=
+SENTRY_WEB_EXPOSED_PORT=9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   web:
     <<: *defaults
     ports:
-      - '9000:9000'
+      - '${SENTRY_WEB_EXPOSED_PORT:-9000}:9000'
 
   cron:
     <<: *defaults


### PR DESCRIPTION
As a follow up from this PR https://github.com/getsentry/onpremise/pull/306, could be possible to include this similar solution to the stable version?

I also have the need to customize the exposed port of the sentry web container due to some incompatibilities with XDebug, which uses the same 9000 port. I'd be nice to have the customization of this variable also in the stable release :)