### PR TITLE
fix(migration): Move Snuba bootstrapping before DB upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -101,7 +101,7 @@ $dc build --force-rm
 echo ""
 echo "Docker images built."
 
-echo "Boostrapping Snuba..."
+echo "Bootstrapping Snuba..."
 $dc up -d kafka redis clickhouse
 until $($dcr clickhouse clickhouse-client -h clickhouse --query="SHOW TABLES;" | grep -q sentry_local); do
   # `bootstrap` is for fresh installs, and `migrate` is for existing installs


### PR DESCRIPTION
Since we are [moving the eventstream into a proper db migration](https://github.com/getsentry/sentry/pull/16226), we need Snuba and its friends ready at the time of `sentry upgrade` command. This patch does exactly that.

Unblocks https://github.com/getsentry/sentry/pull/16226