### PR TITLE
ref(settings): Changing search class to use new class name

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -134,7 +134,7 @@ SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"
 # SNUBA #
 #########
 
-SENTRY_SEARCH = "sentry.search.snuba.SnubaSearchBackend"
+SENTRY_SEARCH = "sentry.search.snuba.EventsDatasetSnubaSearchBackend"
 SENTRY_SEARCH_OPTIONS = {}
 SENTRY_TAGSTORE_OPTIONS = {}
 


### PR DESCRIPTION
This is just a refactor. The class does the same thing, but has been renamed.