### PR TITLE
build(compose): Bump required compose version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ log_file="sentry_install_log-`date +'%Y-%m-%d_%H-%M-%S'`.txt"
 exec &> >(tee -a "$log_file")
 
 MIN_DOCKER_VERSION='17.05.0'
-MIN_COMPOSE_VERSION='1.19.0'
+MIN_COMPOSE_VERSION='1.23.0'
 MIN_RAM=2400 # MB
 
 SENTRY_CONFIG_PY='sentry/sentry.conf.py'


### PR DESCRIPTION
With #343, we added the `--parallel` flag which only got introduced in `docker-compose` `1.23.0` (source https://medium.com/schkn/parallelize-your-docker-compose-build-8ac653e3e596 as Docker docs themselves don't really mention these) so bumping the minimum required version.

Fixes #351.