### PR TITLE
fix(config): parse env variable as int

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -29,7 +29,7 @@ SENTRY_USE_BIG_INTS = True
 # and thus various UI optimizations should be enabled.
 SENTRY_SINGLE_ORGANIZATION = True
 
-SENTRY_OPTIONS["system.event-retention-days"] = env('SENTRY_EVENT_RETENTION_DAYS') or 90
+SENTRY_OPTIONS["system.event-retention-days"] = int(env('SENTRY_EVENT_RETENTION_DAYS', '90'))
 
 #########
 # Redis #


### PR DESCRIPTION
- parse SENTRY_EVENT_RETENTION_DAYS as integer in case it is defined as a string like in kubernetes