### PR TITLE
fix(install): Update exit status and fix premature exit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -49,24 +49,24 @@ function ensure_file_from_example {
 
 if [ $(ver $DOCKER_VERSION) -lt $(ver $MIN_DOCKER_VERSION) ]; then
     echo "FAIL: Expected minimum Docker version to be $MIN_DOCKER_VERSION but found $DOCKER_VERSION"
-    exit -1
+    exit 1
 fi
 
 if [ $(ver $COMPOSE_VERSION) -lt $(ver $MIN_COMPOSE_VERSION) ]; then
     echo "FAIL: Expected minimum docker-compose version to be $MIN_COMPOSE_VERSION but found $COMPOSE_VERSION"
-    exit -1
+    exit 1
 fi
 
 if [ "$RAM_AVAILABLE_IN_DOCKER" -lt "$MIN_RAM" ]; then
     echo "FAIL: Expected minimum RAM available to Docker to be $MIN_RAM MB but found $RAM_AVAILABLE_IN_DOCKER MB"
-    exit -1
+    exit 1
 fi
 
 #SSE4.2 required by Clickhouse (https://clickhouse.yandex/docs/en/operations/requirements/) 
-SUPPORTS_SSE42=$(docker run --rm busybox grep -c sse4_2 /proc/cpuinfo);
+SUPPORTS_SSE42=$(docker run --rm busybox grep -c sse4_2 /proc/cpuinfo || :);
 if (($SUPPORTS_SSE42 == 0)); then
     echo "FAIL: The CPU your machine is running on does not support the SSE 4.2 instruction set, which is required for one of the services Sentry uses (Clickhouse). See https://git.io/JvLDt for more info."
-    exit -1
+    exit 1
 fi
 
 # Clean up old stuff and ensure nothing is working while we install/update


### PR DESCRIPTION
Update exit -1 to exit 1 in line with best practices
Fixes premature exit of the script when checking for sse42 support. The script would exit before displaying the reason for failure to the user.

discussion started here: https://github.com/getsentry/onpremise/issues/370

I have opted for the simplest fix unless it is needed that the cleanup script runs after the version checks fail.