### PR TITLE
docs(versioning): Add section about versioning and SENTRY_IMAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ We currently support a very minimal set of environment variables to promote othe
 
 If you have any issues or questions, our [Community Forum](https://forum.sentry.io/c/on-premise) is at your service! Everytime you run the install script, it will generate a log file, `sentry_install_log-<ISO_TIMESTAMP>.txt` with the output. Sharing these logs would help people diagnose any issues you might be having.
 
+## Versioning
+
+We continously push the Docker image for each commit made into [Sentry](https://github.com/getsentry/sentry), and other services such as [Snuba](https://github.com/getsentry/snuba) or [Symbolicator](https://github.com/getsentry/symbolicator) to [our Docker Hub](https://hub.docker.com/u/getsentry) and tag the latest version on master as `:lastest`. This is also usually what we have on sentry.io and what the install script uses. You can use a custom Sentry image, such as a modified version that you have built on your own, or simply a specific commit (or pull request) by setting the `SENTRY_IMAGE` environment variable to that image name before running `./install.sh`:
+
+```shell
+SENTRY_IMAGE=getsentry/sentry:10 ./install.sh
+```
+
+If you want to use different or specific images for other services, you may create a `docker-compose.overrides.yaml` file in the repo and override the `image` field for the corresponding services.
+
+We strongly recommend keeping the `latest` tags for all, if you are using this repository directly. We also recommend using specific commit tags if you are consuming any of our Docker images in an environment that needs consistent deploys such as [a Helm chart](https://github.com/helm/charts/tree/master/stable/sentry).
+
 ## Event Retention
 
 Sentry comes with a cleanup cron job that prunes events older than `90 days` by default. If you want to change that, you can change the `SENTRY_EVENT_RETENTION_DAYS` environment variable in `.env` or simply override it in your environment. If you do not want the cleanup cron, you can remove the `sentry-cleanup` service from the `docker-compose.yml`file.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@ If you have any issues or questions, our [Community Forum](https://forum.sentry.
 
 ## Versioning
 
-We continously push the Docker image for each commit made into [Sentry](https://github.com/getsentry/sentry), and other services such as [Snuba](https://github.com/getsentry/snuba) or [Symbolicator](https://github.com/getsentry/symbolicator) to [our Docker Hub](https://hub.docker.com/u/getsentry) and tag the latest version on master as `:lastest`. This is also usually what we have on sentry.io and what the install script uses. You can use a custom Sentry image, such as a modified version that you have built on your own, or simply a specific commit (or pull request) by setting the `SENTRY_IMAGE` environment variable to that image name before running `./install.sh`:
+We continously push the Docker image for each commit made into [Sentry](https://github.com/getsentry/sentry), and other services such as [Snuba](https://github.com/getsentry/snuba) or [Symbolicator](https://github.com/getsentry/symbolicator) to [our Docker Hub](https://hub.docker.com/u/getsentry) and tag the latest version on master as `:lastest`. This is also usually what we have on sentry.io and what the install script uses. You can use a custom Sentry image, such as a modified version that you have built on your own, or simply a specific commit hash by setting the `SENTRY_IMAGE` environment variable to that image name before running `./install.sh`:
 
 ```shell
 SENTRY_IMAGE=getsentry/sentry:10 ./install.sh
+```
+
+or
+
+```shell
+SENTRY_IMAGE=getsentry/sentry:83b1380 ./install.sh
 ```
 
 If you want to use different or specific images for other services, you may create a `docker-compose.overrides.yaml` file in the repo and override the `image` field for the corresponding services.


### PR DESCRIPTION
This addreses multiple questions raised about how to install a specific version of Sentry or using specific versions for images such as #378, #355, #348, and #326.