### PR TITLE
Make secret key generation idempotent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,8 +90,8 @@ ensure_file_from_example $SENTRY_CONFIG_PY
 ensure_file_from_example $SENTRY_CONFIG_YML
 ensure_file_from_example $SENTRY_EXTRA_REQUIREMENTS
 
-echo ""
 if grep -xq "system.secret-key: '!!changeme!!'" $SENTRY_CONFIG_YML ; then
+    echo ""
     echo "Generating secret key..."
     # This is to escape the secret key to be used in sed below
     # Note the need to set LC_ALL=C due to BSD tr and sed always trying to decode

--- a/install.sh
+++ b/install.sh
@@ -91,13 +91,15 @@ ensure_file_from_example $SENTRY_CONFIG_YML
 ensure_file_from_example $SENTRY_EXTRA_REQUIREMENTS
 
 echo ""
-echo "Generating secret key..."
-# This is to escape the secret key to be used in sed below
-# Note the need to set LC_ALL=C due to BSD tr and sed always trying to decode
-# whatever is passed to them. Kudos to https://stackoverflow.com/a/23584470/90297
-SECRET_KEY=$(export LC_ALL=C; head /dev/urandom | tr -dc "a-z0-9@#%^&*(-_=+)" | head -c 50 | sed -e 's/[\/&]/\\&/g')
-sed -i -e 's/^system.secret-key:.*$/system.secret-key: '"'$SECRET_KEY'"'/' $SENTRY_CONFIG_YML
-echo "Secret key written to $SENTRY_CONFIG_YML"
+if grep -xq "system.secret-key: '!!changeme!!'" $SENTRY_CONFIG_YML ; then
+    echo "Generating secret key..."
+    # This is to escape the secret key to be used in sed below
+    # Note the need to set LC_ALL=C due to BSD tr and sed always trying to decode
+    # whatever is passed to them. Kudos to https://stackoverflow.com/a/23584470/90297
+    SECRET_KEY=$(export LC_ALL=C; head /dev/urandom | tr -dc "a-z0-9@#%^&*(-_=+)" | head -c 50 | sed -e 's/[\/&]/\\&/g')
+    sed -i -e 's/^system.secret-key:.*$/system.secret-key: '"'$SECRET_KEY'"'/' $SENTRY_CONFIG_YML
+    echo "Secret key written to $SENTRY_CONFIG_YML"
+fi
 
 echo ""
 echo "Building and tagging Docker images..."


### PR DESCRIPTION
Issue: I'm deploying sentry onpremise via ansible. After I make changes to the configuration I re-run the install script to update the configuration. But every run of the install script will re-generate the secret key, and therefore trigger the (update) install handler every ansible run.

Solution: Only generate a secret key if the default key has not been changed.