### PR TITLE
Require docker compose version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docke
 ## Requirements
 
  * Docker 17.05.0+
- * Compose 1.19.0+
+ * Compose 1.23.0+
 
 ## Minimum Hardware Requirements:
 


### PR DESCRIPTION
install.sh requires a higher (not in Debian buster available version)