### PR TITLE
feat(config): Mount config as a volume to Sentry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,11 @@ x-sentry-defaults: &sentry_defaults
     - symbolicator
     - kafka
   environment:
+    SENTRY_CONF: '/etc/sentry'
     SNUBA: 'http://snuba-api:1218'
   volumes:
     - 'sentry-data:/data'
+    - './sentry:/etc/sentry'
 x-snuba-defaults: &snuba_defaults
   << : *restart_policy
   depends_on:

--- a/sentry/.dockerignore
+++ b/sentry/.dockerignore
@@ -1,0 +1,5 @@
+# Ignore everything
+*
+
+# Only allow requirements.txt
+!/requirements.txt

--- a/sentry/Dockerfile
+++ b/sentry/Dockerfile
@@ -1,18 +1,7 @@
 ARG SENTRY_IMAGE
 FROM ${SENTRY_IMAGE:-getsentry/sentry:latest}
 
-WORKDIR /usr/src/sentry
-
-# Add WORKDIR to PYTHONPATH so local python files don't need to be installed
-ENV PYTHONPATH /usr/src/sentry
 COPY . /usr/src/sentry
 
 # Hook for installing additional plugins
 RUN if [ -s requirements.txt ]; then pip install -r requirements.txt; fi
-
-# Hook for installing a local app as an addon
-RUN if [ -s setup.py ]; then pip install -e .; fi
-
-# Hook for staging in custom configs
-RUN if [ -s sentry.conf.py ]; then cp sentry.conf.py $SENTRY_CONF/; fi \
-	&& if [ -s config.yml ]; then cp config.yml $SENTRY_CONF/; fi


### PR DESCRIPTION
This follows the best-practice of mounting the config folder as a volume and removes the need to rebuild sentry images for config changes. Partially addresses #314.

This removes the ability to directly install a python project from inside the folder. I don't think this feature was relevant or useful for this particular on-premise setup/layout anyway.