### PR TITLE
Fix regression from #407 for requirements install

### DIFF
--- a/sentry/Dockerfile
+++ b/sentry/Dockerfile
@@ -4,4 +4,4 @@ FROM ${SENTRY_IMAGE:-getsentry/sentry:latest}
 COPY . /usr/src/sentry
 
 # Hook for installing additional plugins
-RUN if [ -s requirements.txt ]; then pip install -r requirements.txt; fi
+RUN if [ -s /usr/src/sentry/requirements.txt ]; then pip install -r /usr/src/sentry/requirements.txt; fi


### PR DESCRIPTION
Changing the sentry/Dockerfile to remove the WORKDIR caused the RUN install requirements to use the wrong directory as context.

The change that broke this build can be found here: https://github.com/getsentry/onpremise/commit/5f7c18bd187c649048de53c75a2fac56a4c6a5da#diff-d3d372b1d4bc8f4b875c733e504d59c9L4

I was able to test this on my build locally to verify that it works. I'm not sure if there are other implications from that PR or not. 

Related to: #407 