### PR TITLE
fix: Add snuba outcomes consumers to setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,10 +107,10 @@ services:
     << : *snuba_defaults
     command: consumer --dataset events --auto-offset-reset=latest --max-batch-time-ms 750
   # Kafka consumer responsible for feeding outcomes into Clickhouse
+  # Use --auto-offset-reset=earliest to recover up to 7 days of TSDB data
+  # since we did not do a proper migration
   snuba-outcomes-consumer:
     << : *snuba_defaults
-    # Use --auto-offset-reset=earliest to recover up to 7 days of TSDB data
-    # since we did not do a proper migration
     command: consumer --dataset outcomes --auto-offset-reset=earliest --max-batch-time-ms 750
   snuba-replacer:
     << : *snuba_defaults

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ x-sentry-defaults: &sentry_defaults
     - memcached
     - smtp
     - snuba-api
-    - snuba-consumer
+    - snuba-events-consumer
+    - snuba-outcomes-consumer
     - snuba-replacer
     - symbolicator
     - kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,9 +101,12 @@ services:
       - 'sentry-clickhouse-log:/var/log/clickhouse-server'
   snuba-api:
     << : *snuba_defaults
-  snuba-consumer:
+  snuba-events-consumer:
     << : *snuba_defaults
-    command: consumer --auto-offset-reset=latest --max-batch-time-ms 750
+    command: consumer --dataset events --auto-offset-reset=latest --max-batch-time-ms 750
+  snuba-outcomes-consumer:
+    << : *snuba_defaults
+    command: consumer --dataset outcomes --auto-offset-reset=latest --max-batch-time-ms 750
   snuba-replacer:
     << : *snuba_defaults
     command: replacer --auto-offset-reset=latest --max-batch-size 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ x-sentry-defaults: &sentry_defaults
     - memcached
     - smtp
     - snuba-api
-    - snuba-events-consumer
+    - snuba-consumer
     - snuba-outcomes-consumer
     - snuba-replacer
     - symbolicator
@@ -102,9 +102,11 @@ services:
       - 'sentry-clickhouse-log:/var/log/clickhouse-server'
   snuba-api:
     << : *snuba_defaults
-  snuba-events-consumer:
+  # Kafka consumer responsible for feeding events into Clickhouse
+  snuba-consumer:
     << : *snuba_defaults
     command: consumer --dataset events --auto-offset-reset=latest --max-batch-time-ms 750
+  # Kafka consumer responsible for feeding outcomes into Clickhouse
   snuba-outcomes-consumer:
     << : *snuba_defaults
     command: consumer --dataset outcomes --auto-offset-reset=latest --max-batch-time-ms 750

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,9 @@ services:
   # Kafka consumer responsible for feeding outcomes into Clickhouse
   snuba-outcomes-consumer:
     << : *snuba_defaults
-    command: consumer --dataset outcomes --auto-offset-reset=latest --max-batch-time-ms 750
+    # Use --auto-offset-reset=earliest to recover up to 7 days of TSDB data
+    # since we did not do a proper migration
+    command: consumer --dataset outcomes --auto-offset-reset=earliest --max-batch-time-ms 750
   snuba-replacer:
     << : *snuba_defaults
     command: replacer --auto-offset-reset=latest --max-batch-size 3


### PR DESCRIPTION
TSDB is currently broken because we've been using redissnuba backend without running the consumers.

Add outcomes consumers with an odd value for `auto-offset-reset` to attempt to recover TSDB data from outcomes.