### PR TITLE
docs(readme): Remove link to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ The included `install.sh` script is meant to be idempotent and to bring you to t
 
  * [Documentation](https://docs.sentry.io/server/)
  * [Bug Tracker](https://github.com/getsentry/onpremise/issues)
- * [Forums](https://forum.sentry.io/c/on-premise)
- * [Discord](https://discord.gg/mg5V76F) (Sentry Community, #sentry-server)
+ * [Community Forums](https://forum.sentry.io/c/on-premise)
 
 
 [build-status-image]: https://api.travis-ci.com/getsentry/onpremise.svg?branch=master


### PR DESCRIPTION
We don't provide great support for Sentry Server over at Discord so remove the reference to it from the README