### PR TITLE
Use restart-policy for nginx & relay

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,7 @@ services:
         BASE_IMAGE: 'sentry-onpremise-local'
     command: '"0 0 * * * gosu sentry sentry cleanup --days $SENTRY_EVENT_RETENTION_DAYS"'
   nginx:
+    << : *restart_policy
     ports:
       - '9000:80/tcp'
     image: "nginx:1.16"
@@ -175,6 +176,7 @@ services:
       - web
       - relay
   relay:
+    << : *restart_policy
     image: "us.gcr.io/sentryio/relay:latest"
     command: 'run --config /etc/relay'
     volumes:


### PR DESCRIPTION
All the other services have a restart-policy, apart from these new ones added in #421