### PR TITLE
fix(relay): Fix failed to write credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,7 @@ services:
     command: 'run --config /etc/relay'
     volumes:
       - type: bind
+        read_only: true
         source: ./relay
         target: /etc/relay
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,12 +178,11 @@ services:
   relay:
     << : *restart_policy
     image: "us.gcr.io/sentryio/relay:latest"
-    command: 'run --config /etc/relay'
     volumes:
       - type: bind
         read_only: true
         source: ./relay
-        target: /etc/relay
+        target: /work/.relay
     depends_on:
       - kafka
       - redis

--- a/relay/config.yml
+++ b/relay/config.yml
@@ -3,9 +3,8 @@ relay:
   upstream: "http://web:9000/"
   host: 0.0.0.0
   port: 3000
-#logging:
-#  # Available logging levels: TRACE, DEBUG, INFO, WARN, ERROR
-#  level: WARN
+logging:
+ level: WARN
 processing:
   enabled: true
   kafka_config:


### PR DESCRIPTION
Fixes the issue reported on https://github.com/getsentry/onpremise/pull/421#issuecomment-619434942 and https://forum.sentry.io/t/could-not-write-etc-relay-credentials-json/9558?u=byk

Follow up to #421.