### PR TITLE
fix(relay): Use Docker Hub as relay image registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,7 @@ services:
       - relay
   relay:
     << : *restart_policy
-    image: "us.gcr.io/sentryio/relay:latest"
+    image: "getsentry/relay:latest"
     volumes:
       - type: bind
         read_only: true


### PR DESCRIPTION
We regularly prune old Google Cloud Build images and also GCB registry is not accessible to everyone all the time (firewall settings, being in China, etc.)

Fixes #445.