### PR TITLE
fix(nginx): Fix proxy settings for Sentry

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,8 +19,6 @@ http {
 
     sendfile        on;
     keepalive_timeout  65;
-    proxy_buffering off;
-    proxy_request_buffering off;
 
     upstream relay {
         server relay:3000;
@@ -35,6 +33,10 @@ http {
         # use the docker DNS server to resolve ips for relay and sentry containers
         resolver 127.0.0.11 ipv6=off;
         client_max_body_size 100M;
+
+        proxy_redirect off;
+        proxy_set_header Host       $host;
+
         location /api/store/ {
             proxy_pass http://relay;
         }
@@ -43,8 +45,6 @@ http {
         }
         location / {
            proxy_pass http://sentry;
-           proxy_redirect off;
-           proxy_set_header Host       $host;
         }
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,7 +44,7 @@ http {
         location / {
            proxy_pass http://sentry;
            proxy_redirect off;
-           proxy_set_header Host       $host
+           proxy_set_header Host       $host;
         }
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,8 +18,9 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     sendfile        on;
-
     keepalive_timeout  65;
+    proxy_buffering off;
+    proxy_request_buffering off;
 
     upstream relay {
         server relay:3000;
@@ -42,6 +43,8 @@ http {
         }
         location / {
            proxy_pass http://sentry;
+           proxy_redirect off;
+           proxy_set_header Host       $host
         }
     }
 }

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -29,7 +29,9 @@ SENTRY_USE_BIG_INTS = True
 # and thus various UI optimizations should be enabled.
 SENTRY_SINGLE_ORGANIZATION = True
 
-SENTRY_OPTIONS["system.event-retention-days"] = int(env('SENTRY_EVENT_RETENTION_DAYS', '90'))
+SENTRY_OPTIONS["system.event-retention-days"] = int(
+    env('SENTRY_EVENT_RETENTION_DAYS', '90')
+)
 
 #########
 # Redis #
@@ -153,12 +155,6 @@ SENTRY_DIGESTS = "sentry.digests.backends.redis.RedisBackend"
 SENTRY_WEB_HOST = "0.0.0.0"
 SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {
-    "http": "%s:%s" % (SENTRY_WEB_HOST, SENTRY_WEB_PORT),
-    "protocol": "uwsgi",
-    # This is needed to prevent https://git.io/fj7Lw
-    "uwsgi-socket": None,
-    "http-keepalive": True,
-    "http-chunked-input": True,
     "memory-report": False,
     # 'workers': 3,  # the number of web workers
 }
@@ -220,4 +216,3 @@ GITHUB_EXTENDED_PERMISSIONS = ['repo']
 
 # BITBUCKET_CONSUMER_KEY = 'YOUR_BITBUCKET_CONSUMER_KEY'
 # BITBUCKET_CONSUMER_SECRET = 'YOUR_BITBUCKET_CONSUMER_SECRET'
-


### PR DESCRIPTION
Fixes #447.

This patch should also fix issuer regarding large uploads such as minidumps by turning off any buffering.