### PR TITLE
#439: Added default support for environment-driven configuration.

### DIFF
--- a/docker-compose.env.yml
+++ b/docker-compose.env.yml
@@ -1,0 +1,122 @@
+version: '3.4'
+
+# All environment variables referenced from
+# https://github.com/getsentry/sentry/blob/master/docker/sentry.conf.py
+#
+x-restart-policy-run-once: &restart_policy_run_once
+  restart: on-failure
+x-sentry-defaults-override: &sentry_defaults_override
+  environment:
+    SENTRY_CONF: '/etc/sentry'
+    SNUBA: ${SENTRY_SNUBA_API:-http://snuba-api:1218}
+    SENTRY_POSTGRES_HOST: ${SENTRY_POSTGRES_HOST:-postgres}
+    SENTRY_POSTGRES_PORT: ${SENTRY_POSTGRES_PORT}
+    SENTRY_DB_NAME: ${SENTRY_DB_NAME:-postgres}
+    SENTRY_DB_USER: ${SENTRY_DB_USER:-postgres}
+    SENTRY_DB_PASSWORD: ${SENTRY_DB_PASSWORD}
+    SENTRY_RABBITMQ_HOST: ${SENTRY_RABBITMQ_HOST}
+    SENTRY_RABBITMQ_USERNAME: ${SENTRY_RABBITMQ_USERNAME:-guest}
+    SENTRY_RABBITMQ_PASSWORD: ${SENTRY_RABBITMQ_PASSWORD:-guest}
+    SENTRY_RABBITMQ_VHOST: ${SENTRY_RABBITMQ_VHOST:-/}
+    SENTRY_REDIS_HOST: ${SENTRY_REDIS_HOST:-redis}
+    SENTRY_REDIS_PORT: ${SENTRY_REDIS_PORT:-6379}
+    SENTRY_REDIS_PASSWORD: ${SENTRY_REDIS_PASSWORD}
+    SENTRY_REDIS_DB: ${SENTRY_REDIS_DB:-0}
+    SENTRY_MEMCACHED_HOST: ${SENTRY_MEMCACHED_HOST:-memcached}
+    SENTRY_MEMCACHED_PORT: ${SENTRY_MEMCACHED_PORT:-11211}
+
+    SENTRY_SINGLE_ORGANIZATION: ${SENTRY_SINGLE_ORGANIZATION:-True}
+    SENTRY_SECRET_KEY: ${SENTRY_SECRET_KEY:-super secret secret key}
+    SENTRY_USE_SSL: ${SENTRY_USE_SSL:-False}
+x-snuba-defaults-override: &snuba_defaults_override
+  environment:
+    SNUBA_SETTINGS: docker
+    CLICKHOUSE_HOST: ${SENTRY_CLICKHOUSE_HOST:-clickhouse}
+    DEFAULT_BROKERS: ${SENTRY_KAFKA_HOST:-kafka}:${SENTRY_KAFKA_PORT:-9092}
+    REDIS_HOST: ${SENTRY_REDIS_HOST:-redis}
+    UWSGI_MAX_REQUESTS: '10000'
+    UWSGI_DISABLE_LOGGING: 'true'
+x-snuba-api-init: &snuba_api_init
+  << : *restart_policy_run_once
+  image: 'getsentry/snuba:latest'
+  depends_on:
+    - redis
+    - clickhouse
+    - kafka
+x-sentry-web-init: &sentry_web_init
+  << : *restart_policy_run_once
+  image: 'sentry-onpremise-local'
+  depends_on:
+    - redis
+    - postgres
+    - memcached
+    - smtp
+    - snuba-api
+    - snuba-consumer
+    - snuba-outcomes-consumer
+    - snuba-replacer
+    - symbolicator
+    - kafka
+  volumes:
+    - 'sentry-data:/data'
+
+services:
+  zookeeper:
+    environment:
+      ZOOKEEPER_CLIENT_PORT: ${SENTRY_ZOOKEEPER_PORT:-2181}
+  kafka:
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: ${SENTRY_ZOOKEEPER_HOST:-zookeeper}:${SENTRY_ZOOKEEPER_PORT:-2181}
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://${SENTRY_KAFKA_HOST:-kafka}:${SENTRY_KAFKA_PORT:-9092}"
+  snuba-api:
+    << : *snuba_defaults_override
+  snuba-consumer:
+    << : *snuba_defaults_override
+  snuba-outcomes-consumer:
+    << : *snuba_defaults_override
+  snuba-replacer:
+    << : *snuba_defaults_override
+  snuba-cleanup:
+    << : *snuba_defaults_override
+  web:
+    << : *sentry_defaults_override
+  cron:
+    << : *sentry_defaults_override
+  worker:
+    << : *sentry_defaults_override
+    command: run worker
+  post-process-forwarder:
+    << : *restart_policy_run_once
+    << : *sentry_defaults_override
+  sentry-cleanup:
+    << : *sentry_defaults_override
+
+  # Services which only need to run once on startup
+  #
+  snuba-api-bootstrap:
+    << : *snuba_defaults_override
+    << : *snuba_api_init
+    command: bootstrap --force
+  snuba-api-migrate:
+    << : *snuba_defaults_override
+    << : *snuba_api_init
+    command: migrate
+  sentry-web-upgrade:
+    << : *sentry_defaults_override
+    << : *sentry_web_init
+    command: upgrade --noinput
+volumes:
+  sentry-data:
+    external: false
+  sentry-postgres:
+    external: false
+  sentry-redis:
+    external: false
+  sentry-zookeeper:
+    external: false
+  sentry-kafka:
+    external: false
+  sentry-clickhouse:
+    external: false
+  sentry-symbolicator:
+    external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,11 @@ x-sentry-defaults: &sentry_defaults
     - symbolicator
     - kafka
   environment:
-    SENTRY_CONF: '/etc/sentry'
+    SENTRY_CONF: '/etc/sentry/onpremise'
     SNUBA: 'http://snuba-api:1218'
   volumes:
     - 'sentry-data:/data'
-    - './sentry:/etc/sentry'
+    - './sentry:/etc/sentry/onpremise'
 x-snuba-defaults: &snuba_defaults
   << : *restart_policy
   depends_on:


### PR DESCRIPTION
This pull request addresses #439 and provides environment-driven support which respects existing file mounts and utilizes existing environment configuration from the official Sentry Docker image. This is achieved in two ways:

1) The primary configuration folder is moved from `/etc/sentry` -> `/etc/sentry/onpremise`. This allows the built-in config files to be used (which are environment-driven). 

2) Out-of-the-box configuration is provided by including `docker-compose.env.yml`, which contains defaults to run with exactly the same configuration as provided in the example config files.
