### PR TITLE
feat(slack-integration): add reference to guide

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -89,3 +89,13 @@ transaction-events.force-disable-internal-project: true
 #   privatekeyprivatekeyprivatekeyprivatekey
 #   privatekeyprivatekeyprivatekeyprivatekey
 #   -----END RSA PRIVATE KEY-----
+
+#####################
+# Slack Integration #
+#####################
+
+# Refer to https://forum.sentry.io/t/how-to-configure-slack-in-your-on-prem-sentry/3463 for setup instructions.
+
+# slack.client-id: <'client id'>
+# slack.client-secret: <client secret>
+# slack.verification-token: <verification token>


### PR DESCRIPTION
This PR simply adds a reference to the guide for setting up the Slack integration. The url was obtained from [#249](https://github.com/getsentry/onpremise/issues/249#issuecomment-547117033).