### PR TITLE
feat(snuba): Skip snuba migrate task

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -164,11 +164,8 @@ $dc build --force-rm --parallel
 echo ""
 echo "Docker images built."
 
-echo "Bootstrapping Snuba..."
-# `bootstrap` is for fresh installs, and `migrate` is for existing installs
-# Running them both for both cases is harmless so we blindly run them
+echo "Bootstrapping and migrating Snuba..."
 $dcr snuba-api bootstrap --force
-$dcr snuba-api migrate
 echo ""
 
 # Very naively check whether there's an existing sentry-postgres volume and the PG version in it


### PR DESCRIPTION
Since https://github.com/getsentry/snuba/pull/943 the bootstrap command
performs a full migration. There is no longer a need to run bootstrap
followed by migrate to pick up all of the migration statements.