### PR TITLE
fix(uwsgi): Make sure uWSGI talks proper HTTP/1.1

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,28 +1,28 @@
-user  nginx;
-worker_processes  1;
+user nginx;
+worker_processes 1;
 
-error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
 
 
 events {
-    worker_connections  1024;
+	worker_connections 1024;
 }
 
 
 http {
-    default_type  application/octet-stream;
+	default_type application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+	log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+	'$status $body_bytes_sent "$http_referer" '
+	'"$http_user_agent" "$http_x_forwarded_for"';
 
-	sendfile    on;
-	tcp_nopush  on;
+	sendfile on;
+	tcp_nopush on;
 	tcp_nodelay on;
 	reset_timedout_connection on;
 
-	keepalive_timeout  75s;
+	keepalive_timeout 75s;
 
 	gzip off;
 	server_tokens off;
@@ -32,39 +32,42 @@ http {
 	types_hash_bucket_size 64;
 	client_max_body_size 5m;
 
-	proxy_http_version  1.1;
-	proxy_redirect      off;
-	proxy_buffering     off;
+	proxy_http_version 1.1;
+	proxy_redirect off;
+	proxy_buffering off;
 	proxy_next_upstream error timeout invalid_header http_502 http_503 non_idempotent;
 	proxy_next_upstream_tries 2;
-	proxy_set_header   Connection '';
-	proxy_set_header   Host                 $host;
-	proxy_set_header   X-Real-IP            $remote_addr;
-	proxy_set_header   X-Forwarded-For      $remote_addr;
-	proxy_set_header   X-Forwarded-Proto    $scheme;
-	proxy_set_header   X-Request-Id         $request_id;
+
+	# Remove the Connection header if the client sends it,
+	# it could be "close" to close a keepalive connection
+	proxy_set_header Connection '';
+	proxy_set_header Host $host;
+	proxy_set_header X-Real-IP $remote_addr;
+	proxy_set_header X-Forwarded-For $remote_addr;
+	proxy_set_header X-Forwarded-Proto $scheme;
+	proxy_set_header X-Request-Id $request_id;
 	proxy_read_timeout 30s;
 	proxy_send_timeout 5s;
 
-    upstream relay {
-        server relay:3000;
-    }
+	upstream relay {
+		server relay:3000;
+	}
 
-    upstream sentry {
-        server web:9000;
-    }
+	upstream sentry {
+		server web:9000;
+	}
 
-    server {
-        listen 80;
+	server {
+		listen 80;
 
-        location /api/store/ {
-            proxy_pass http://relay;
-        }
-        location ~ ^/api/[1-9]\d*/ {
-            proxy_pass http://relay;
-        }
-        location / {
-           proxy_pass http://sentry;
-        }
-    }
+		location /api/store/ {
+			proxy_pass http://relay;
+		}
+		location ~ ^/api/[1-9]\d*/ {
+			proxy_pass http://relay;
+		}
+		location / {
+			proxy_pass http://sentry;
+		}
+	}
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,8 +17,34 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    sendfile        on;
-    keepalive_timeout  65;
+	sendfile    on;
+	tcp_nopush  on;
+	tcp_nodelay on;
+	reset_timedout_connection on;
+
+	keepalive_timeout  75s;
+
+	gzip off;
+	server_tokens off;
+
+	server_names_hash_bucket_size 64;
+	types_hash_max_size 2048;
+	types_hash_bucket_size 64;
+	client_max_body_size 5m;
+
+	proxy_http_version  1.1;
+	proxy_redirect      off;
+	proxy_buffering     off;
+	proxy_next_upstream error timeout invalid_header http_502 http_503 non_idempotent;
+	proxy_next_upstream_tries 2;
+	proxy_set_header   Connection '';
+	proxy_set_header   Host                 $host;
+	proxy_set_header   X-Real-IP            $remote_addr;
+	proxy_set_header   X-Forwarded-For      $remote_addr;
+	proxy_set_header   X-Forwarded-Proto    $scheme;
+	proxy_set_header   X-Request-Id         $request_id;
+	proxy_read_timeout 30s;
+	proxy_send_timeout 5s;
 
     upstream relay {
         server relay:3000;
@@ -30,12 +56,6 @@ http {
 
     server {
         listen 80;
-        # use the docker DNS server to resolve ips for relay and sentry containers
-        resolver 127.0.0.11 ipv6=off;
-        client_max_body_size 100M;
-
-        proxy_redirect off;
-        proxy_set_header Host       $host;
 
         location /api/store/ {
             proxy_pass http://relay;

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -158,12 +158,11 @@ SENTRY_WEB_OPTIONS = {
     # These ase for proper HTTP/1.1 support from uWSGI
     # Without these it doesn't do keep-alives causing
     # issues with Relay's direct requests.
-    "http": "%s:%s" % (SENTRY_WEB_HOST, SENTRY_WEB_PORT),
-    "protocol": "uwsgi",
-    # This is needed to prevent https://git.io/fj7Lw
-    "uwsgi-socket": None,
     "http-keepalive": True,
     "http-chunked-input": True,
+    # the number of web workers
+    'workers': 3,
+    # Turn off memory reporting
     "memory-report": False,
     # Some stuff so uwsgi will cycle workers sensibly
     'max-requests': 100000,
@@ -180,7 +179,6 @@ SENTRY_WEB_OPTIONS = {
     'ignore-sigpipe': True,
     'ignore-write-errors': True,
     'disable-write-exception': True,
-    # 'workers': 3,  # the number of web workers
 }
 
 ###########

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -155,7 +155,31 @@ SENTRY_DIGESTS = "sentry.digests.backends.redis.RedisBackend"
 SENTRY_WEB_HOST = "0.0.0.0"
 SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {
+    # These ase for proper HTTP/1.1 support from uWSGI
+    # Without these it doesn't do keep-alives causing
+    # issues with Relay's direct requests.
+    "http": "%s:%s" % (SENTRY_WEB_HOST, SENTRY_WEB_PORT),
+    "protocol": "uwsgi",
+    # This is needed to prevent https://git.io/fj7Lw
+    "uwsgi-socket": None,
+    "http-keepalive": True,
+    "http-chunked-input": True,
     "memory-report": False,
+    # Some stuff so uwsgi will cycle workers sensibly
+    'max-requests': 100000,
+    'max-requests-delta': 500,
+    'max-worker-lifetime': 86400,
+    # Duplicate options from sentry default just so we don't get
+    # bit by sentry changing a default value that we depend on.
+    'thunder-lock': True,
+    'log-x-forwarded-for': False,
+    'buffer-size': 32768,
+    'limit-post': 209715200,
+    'disable-logging': True,
+    'reload-on-rss': 600,
+    'ignore-sigpipe': True,
+    'ignore-write-errors': True,
+    'disable-write-exception': True,
     # 'workers': 3,  # the number of web workers
 }
 


### PR DESCRIPTION
This patch brings back the HTTP/1.1 related settings for uWSGI to fix #486 as apparently Relay tries to talk to Sentry Web with keep alives where uWSGI terminates the connection unexpectedly. It also ports some configs for uWSGI and nginx from single-tenant.