### PR TITLE
ref(sentry): Remove explicit Discover v2 flags

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -206,9 +206,6 @@ SENTRY_FEATURES.update(
         for feature in (
             "organizations:discover",
             "organizations:events",
-            "organizations:discover-basic",
-            "organizations:discover-query",
-            "organizations:events-v2",
             "organizations:global-views",
             "organizations:integrations-issue-basic",
             "organizations:integrations-issue-sync",


### PR DESCRIPTION
Discover v2 is now enabled by default: getsentry/sentry#19023