### PR TITLE
fix(relay): Increase Kafka message size limit to 50MB

### DIFF
--- a/relay/config.yml
+++ b/relay/config.yml
@@ -9,4 +9,5 @@ processing:
   enabled: true
   kafka_config:
     - {name: "bootstrap.servers", value: "kafka:9092"}
+    - {name: "message.max.bytes", value: 50000000} #50MB or bust
   redis: redis://redis:6379


### PR DESCRIPTION
Based on my forum post https://forum.sentry.io/t/sentry-native-and-kafka-messagesizetoolarge-error/9948
In short I tried to send minidumps more than 1mb(in fact 2mb), and relay service failed to store event, with kafka error `MessageSizeTooLarge`.
You can reproduce this if you recreate install this on local machine, create simple native project, and send minidump file more than 1mb via curl like suggested in docs or in web ui. And check the logs.

I reason selected value of 50mb on https://github.com/getsentry/onpremise/blob/master/docker-compose.yml#L87, like you already hardcoded on kafka service.
