### PR TITLE
Fixing Relay authorization issue

### DIFF
--- a/relay/config.yml
+++ b/relay/config.yml
@@ -1,6 +1,6 @@
 ---
 relay:
-  upstream: "http://web:9000/"
+  upstream: "http://nginx/"
   host: 0.0.0.0
   port: 3000
 logging:


### PR DESCRIPTION
credentials are correct `SENTRY_RELAY_WHITELIST_PK` contains correct key but auth still fails. 

was able to fix issue only after forced relay to communicate via Nginx, not directly.  (did not had more time to troubleshoot network communication and do some tcpdump capture analyses)

