### PR TITLE
fix(slack): Add note about legacy app flag for newly created bots

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -99,3 +99,5 @@ transaction-events.force-disable-internal-project: true
 # slack.client-id: <'client id'>
 # slack.client-secret: <client secret>
 # slack.verification-token: <verification token>
+## only uncomment legacy-app if you made your slack bot after july 2020
+# slack.legacy-app: False


### PR DESCRIPTION
This is all i needed to get the plugin working after the latest changes in https://github.com/getsentry/sentry/pull/19446 

due to the default being true it meant certain endpoints just borked on the newer api