### PR TITLE
Make cron entrypoint.sh executable

### DIFF
--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -3,4 +3,5 @@ FROM ${BASE_IMAGE}
 RUN apt-get update && apt-get install -y --no-install-recommends cron && \
     rm -r /var/lib/apt/lists/*
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Shell scripts lost their executable permissions while downloading project from GitHub, modifying it to my needs and later copying it to server. I had to manually set executable parameter for install script, but forgot about other scripts. When images were built, cron containers could not start. There were errors:
```
ERROR: for sentry_onpremise_symbolicator-cleanup_1  Cannot start service symbolicator-cleanup: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/entrypoint.sh\": permission denied": unknown

ERROR: for symbolicator-cleanup  Cannot start service symbolicator-cleanup: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/entrypoint.sh\": permission denied": unknown

ERROR: for snuba-cleanup  Cannot start service snuba-cleanup: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/entrypoint.sh\": permission denied": unknown

ERROR: for sentry-cleanup  Cannot start service sentry-cleanup: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"/entrypoint.sh\": permission denied": unknown
ERROR: Encountered errors while bringing up the project.
```
I think it's a good idea to explicitly set cron image's executable permissions in Dockerfile, so image builds correclty in all environments.