### PR TITLE
fix(relay): Fix relay cannot authenticate w/ Sentry

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -173,7 +173,7 @@ SENTRY_WEB_OPTIONS = {
     'thunder-lock': True,
     'log-x-forwarded-for': False,
     'buffer-size': 32768,
-    # Realy cannot authenticate without the following
+    # Relay cannot authenticate without the following
     'post-buffering': 32768,
     'limit-post': 209715200,
     'disable-logging': True,

--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -155,13 +155,13 @@ SENTRY_DIGESTS = "sentry.digests.backends.redis.RedisBackend"
 SENTRY_WEB_HOST = "0.0.0.0"
 SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {
-    # These ase for proper HTTP/1.1 support from uWSGI
-    # Without these it doesn't do keep-alives causing
-    # issues with Relay's direct requests.
     "http-keepalive": True,
+    "so-keepalive": True,
+    "http-auto-chunked": True,
     "http-chunked-input": True,
     # the number of web workers
     'workers': 3,
+    'threads': 4,
     # Turn off memory reporting
     "memory-report": False,
     # Some stuff so uwsgi will cycle workers sensibly
@@ -173,6 +173,8 @@ SENTRY_WEB_OPTIONS = {
     'thunder-lock': True,
     'log-x-forwarded-for': False,
     'buffer-size': 32768,
+    # Realy cannot authenticate without the following
+    'post-buffering': 32768,
     'limit-post': 209715200,
     'disable-logging': True,
     'reload-on-rss': 600,


### PR DESCRIPTION
Fix #486.

I finally figured out what the issue was: a missing `post-buffering` option to let Relay finish it's POST request for auth. This PR supersedes #543.
