### PR TITLE
fix(superuser): Don't set INTERNAL_IPS to Docker network

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -30,8 +30,8 @@ def get_internal_network():
     return ("{0:s}/{1:d}".format(base, netmask_bits),)
 
 
-INTERNAL_IPS = get_internal_network()
-INTERNAL_SYSTEM_IPS = INTERNAL_IPS
+INTERNAL_SYSTEM_IPS = get_internal_network()
+
 
 DATABASES = {
     "default": {


### PR DESCRIPTION
`INTERNAL_IPS` is used to check whether to allow superuser access or not. Limiting this to the Docker internal network makes it impossible for anyone to reach admin pages with on-premise setup.

This is a follow up to #572 and it fixes #577.
