### PR TITLE
feat: Enable performance views for on-premise

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -246,6 +246,7 @@ SENTRY_FEATURES.update(
             "organizations:sso-basic",
             "organizations:sso-rippling",
             "organizations:sso-saml2",
+            "organizations:performance-view",
             "projects:custom-inbound-filters",
             "projects:data-forwarding",
             "projects:discard-groups",


### PR DESCRIPTION
The discover-basic and discover-query feature flags are enabled by default in the built-in sentry/conf/server.py

Closes #582