### PR TITLE
fix(snuba): Add consumer group to transactions consumer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
   # Kafka consumer responsible for feeding transactions data into Clickhouse
   snuba-transactions-consumer:
     << : *snuba_defaults
-    command: consumer --storage transactions --auto-offset-reset=latest --max-batch-time-ms 750
+    command: consumer --storage transactions --consumer-group transactions_group --auto-offset-reset=latest --max-batch-time-ms 750
   snuba-replacer:
     << : *snuba_defaults
     command: replacer --storage events --auto-offset-reset=latest --max-batch-size 3


### PR DESCRIPTION
Without the consumer-group option, transactions consumer and events consumer will compete for messages on the same topic and usually events win, which is the first one. This may cause some data loss for performance and make it seem not work.

Should address https://forum.sentry.io/t/perfomance-tracing-for-sentry-itself/10405/5?u=byk
