### PR TITLE
feat(compose): Add ability to use custom images for any Sentry service

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,6 @@
 COMPOSE_PROJECT_NAME=sentry_onpremise
 SENTRY_EVENT_RETENTION_DAYS=90
-SENTRY_VERSION=latest
-SYMBOLICATOR_VERSION=latest
+SENTRY_IMAGE=getsentry/sentry:latest
+SNUBA_IMAGE=getsentry/snuba:latest
+RELAY_IMAGE=getsentry/relay:latest
+SYMBOLICATOR_IMAGE=getsentry/symbolicator:eac35a6058c7749bdf20ed219a377e49e02d0b76

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ x-sentry-defaults: &sentry_defaults
     context: ./sentry
     args:
       - SENTRY_IMAGE
-      - SENTRY_VERSION
   image: sentry-onpremise-local
   depends_on:
     - redis
@@ -34,7 +33,7 @@ x-snuba-defaults: &snuba_defaults
     - redis
     - clickhouse
     - kafka
-  image: 'getsentry/snuba:$SENTRY_VERSION'
+  image: '$SNUBA_IMAGE'
   environment:
     SNUBA_SETTINGS: docker
     CLICKHOUSE_HOST: clickhouse
@@ -134,11 +133,11 @@ services:
     build:
       context: ./cron
       args:
-        BASE_IMAGE: 'getsentry/snuba:$SENTRY_VERSION'
+        BASE_IMAGE: '$SNUBA_IMAGE'
     command: '"*/5 * * * * gosu snuba snuba cleanup --dry-run False"'
   symbolicator:
     << : *restart_policy
-    image: 'getsentry/symbolicator:$SYMBOLICATOR_VERSION'
+    image: '$SYMBOLICATOR_IMAGE'
     volumes:
       - 'sentry-symbolicator:/data'
       - type: bind
@@ -152,7 +151,7 @@ services:
     build:
       context: ./cron
       args:
-        BASE_IMAGE: 'getsentry/symbolicator:$SYMBOLICATOR_VERSION'
+        BASE_IMAGE: '$SYMBOLICATOR_IMAGE'
     command: '"55 23 * * * gosu symbolicator symbolicator cleanup"'
     volumes:
       - 'sentry-symbolicator:/data'
@@ -194,7 +193,7 @@ services:
       - relay
   relay:
     << : *restart_policy
-    image: 'getsentry/relay:$SENTRY_VERSION'
+    image: '$RELAY_IMAGE'
     volumes:
       - type: bind
         read_only: true

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -9,8 +9,8 @@ NEW_VERSION="$2"
 
 SYMBOLICATOR_VERSION=$(curl -sSL 'https://api.github.com/repos/getsentry/symbolicator/git/refs/heads/master' | grep -Po '(?<=\"sha\": \")([a-f0-9]{5,40})(?=\",?)')
 
-sed -i -e "s/^SYMBOLICATOR_VERSION=.*\$/SYMBOLICATOR_VERSION=$SYMBOLICATOR_VERSION/" .env
-sed -i -e "s/^SENTRY_VERSION=.*\$/SENTRY_VERSION=$NEW_VERSION/" .env
+sed -i -e "s/^SYMBOLICATOR_IMAGE=\([^:]\+\):.\+\$/SYMBOLICATOR_IMAGE=\1:$SYMBOLICATOR_VERSION/" .env
+sed -i -e "s/^\(SENTRY\|SNUBA\|RELAY\)_IMAGE=\([^:]\+\):.\+\$/\1_IMAGE=\2:$NEW_VERSION/" .env
 sed -i -e "s/^\# Sentry .* On-Premise/# Sentry $NEW_VERSION On-Premise/" README.md
 sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
 

--- a/sentry/Dockerfile
+++ b/sentry/Dockerfile
@@ -1,6 +1,5 @@
-ARG SENTRY_VERSION=latest
 ARG SENTRY_IMAGE
-FROM ${SENTRY_IMAGE:-getsentry/sentry:$SENTRY_VERSION}
+FROM ${SENTRY_IMAGE}
 
 COPY . /usr/src/sentry
 


### PR DESCRIPTION
This change allows one to override any Sentry service image, mostly for testing purposes. It also removes the SENTRY_VERSION variable as docker-compose makes it very hard to cascade default values for these. Next step is to have integration tests in getsentry/snuba and getsentry/relay (and possibly for getsentry/symbolicator) for getsentry/onpremise using this PR.

Also related: #596.
