### PR TITLE
install: Keep relay available while upgrading

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
 env:
   DOCKER_COMPOSE_VERSION: 1.24.1
-  CI: 1
 jobs:
   test:
     runs-on: ubuntu-16.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
           docker-compose up -d
           printf "Waiting for Sentry to be up"; timeout 60 bash -c 'until $(curl -Isf -o /dev/null http://localhost:9000); do printf '.'; sleep 0.5; done'
           ./test.sh
+          printf "Testing in-place upgrade"
+          ./install.sh --minimize-downtime
+          ./test.sh
 
       - name: Inspect failure
         if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
 env:
   DOCKER_COMPOSE_VERSION: 1.24.1
+  CI: 1
 jobs:
   test:
     runs-on: ubuntu-16.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ script:
   - docker-compose up -d
   - printf "Waiting for Sentry to be up"; timeout 60 bash -c 'until $(curl -Isf -o /dev/null http://localhost:9000); do printf '.'; sleep 0.5; done'
   - ./test.sh
+  - printf "Testing in-place upgrade"
+  - ./install.sh --minimize-downtime
+  - ./test.sh
 
 after_failure:
   - docker-compose ps

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,30 @@ RELAY_CONFIG_YML='relay/config.yml'
 RELAY_CREDENTIALS_JSON='relay/credentials.json'
 SENTRY_EXTRA_REQUIREMENTS='sentry/requirements.txt'
 
+load_options() {
+  while [[ -n "$@" ]]; do
+    case "$1" in
+	    -h | --help) show_help; exit;;
+	    --) ;;
+	    *) echo "Unexpected argument: $1. Use --help for usage information."; exit 1;;
+    esac
+    shift
+  done
+}
+
+show_help() {
+  cat <<EOF
+Usage: $0 [-h | --help]
+
+Install Sentry with docker-compose.
+
+Options:
+ -h, --help             Show this message and exit.
+EOF
+}
+
+load_options $(getopt -n "$0" -o 'h' -l 'help' -- "$@")
+
 # Courtesy of https://stackoverflow.com/a/2183063/90297
 trap_with_arg() {
   func="$1" ; shift

--- a/install.sh
+++ b/install.sh
@@ -20,11 +20,13 @@ SYMBOLICATOR_CONFIG_YML='symbolicator/config.yml'
 RELAY_CONFIG_YML='relay/config.yml'
 RELAY_CREDENTIALS_JSON='relay/credentials.json'
 SENTRY_EXTRA_REQUIREMENTS='sentry/requirements.txt'
+MINIMIZE_DOWNTIME=
 
 load_options() {
   while [[ -n "$@" ]]; do
     case "$1" in
 	    -h | --help) show_help; exit;;
+	    --minimize-downtime) MINIMIZE_DOWNTIME=1;;
 	    --) ;;
 	    *) echo "Unexpected argument: $1. Use --help for usage information."; exit 1;;
     esac
@@ -34,16 +36,19 @@ load_options() {
 
 show_help() {
   cat <<EOF
-Usage: $0 [-h | --help]
+Usage: $0 [-h | --help] [--minimize-downtime]
 
 Install Sentry with docker-compose.
 
 Options:
  -h, --help             Show this message and exit.
+ --minimize-downtime    EXPERIMENTAL: try to keep accepting events for as long as possible while upgrading.
+                        This will disable cleanup on error, and might leave your installation in partially upgraded state.
+                        This option might not reload all configuration, and is only meant for in-place upgrades.
 EOF
 }
 
-load_options $(getopt -n "$0" -o 'h' -l 'help' -- "$@")
+load_options $(getopt -n "$0" -o 'h' -l 'help,minimize-downtime' -- "$@")
 
 # Courtesy of https://stackoverflow.com/a/2183063/90297
 trap_with_arg() {
@@ -63,10 +68,17 @@ cleanup () {
 
   if [ "$1" != "EXIT" ]; then
     echo "An error occurred, caught SIG$1 on line $2";
-    echo "Cleaning up..."
+
+    if [[ "$MINIMIZE_DOWNTIME" ]]; then
+      echo "*NOT* cleaning up, to clean your environment run \"docker-compose stop\"."
+    else
+      echo "Cleaning up..."
+    fi
   fi
 
-  $dc stop &> /dev/null
+  if [[ ! "$MINIMIZE_DOWNTIME" ]]; then
+    $dc stop &> /dev/null
+  fi
 }
 trap_with_arg cleanup ERR INT TERM EXIT
 
@@ -203,11 +215,16 @@ $dc build --force-rm --parallel
 echo ""
 echo "Docker images built."
 
-# Clean up old stuff and ensure nothing is working while we install/update
-# This is for older versions of on-premise:
-$dc -p onpremise down --rmi local --remove-orphans
-# This is for newer versions
-$dc down --rmi local --remove-orphans
+if [[ "$MINIMIZE_DOWNTIME" ]]; then
+  # Stop everything but relay and nginx
+  $dc rm -fsv $($dc config --services |grep -v -e '^nginx$' -e '^relay$')
+else
+  # Clean up old stuff and ensure nothing is working while we install/update
+  # This is for older versions of on-premise:
+  $dc -p onpremise down --rmi local --remove-orphans
+  # This is for newer versions
+  $dc down --rmi local --remove-orphans
+fi
 
 ZOOKEEPER_SNAPSHOT_FOLDER_EXISTS=$($dcr zookeeper bash -c 'ls 2>/dev/null -Ubad1 -- /var/lib/zookeeper/data/version-2 | wc -l | tr -d '[:space:]'')
 if [ "$ZOOKEEPER_SNAPSHOT_FOLDER_EXISTS" -eq "1" ]; then
@@ -311,9 +328,15 @@ if [ ! -f "$RELAY_CREDENTIALS_JSON" ]; then
   echo "Relay credentials written to $RELAY_CREDENTIALS_JSON"
 fi
 
-echo ""
-echo "----------------"
-echo "You're all done! Run the following command to get Sentry running:"
-echo ""
-echo "  docker-compose up -d"
-echo ""
+if [[ "$MINIMIZE_DOWNTIME" ]]; then
+  $dc exec nginx service nginx reload
+  # Start the whole setup, this might restart nginx and relay.
+  $dc up -d --remove-orphans
+else
+  echo ""
+  echo "----------------"
+  echo "You're all done! Run the following command to get Sentry running:"
+  echo ""
+  echo "  docker-compose up -d"
+  echo ""
+fi

--- a/install.sh
+++ b/install.sh
@@ -25,10 +25,10 @@ MINIMIZE_DOWNTIME=
 load_options() {
   while [[ -n "$@" ]]; do
     case "$1" in
-	    -h | --help) show_help; exit;;
-	    --minimize-downtime) MINIMIZE_DOWNTIME=1;;
-	    --) ;;
-	    *) echo "Unexpected argument: $1. Use --help for usage information."; exit 1;;
+        -h | --help) show_help; exit;;
+        --minimize-downtime) MINIMIZE_DOWNTIME=1;;
+        --) ;;
+        *) echo "Unexpected argument: $1. Use --help for usage information."; exit 1;;
     esac
     shift
   done

--- a/install.sh
+++ b/install.sh
@@ -217,7 +217,7 @@ echo "Docker images built."
 
 if [[ "$MINIMIZE_DOWNTIME" ]]; then
   # Stop everything but relay and nginx
-  $dc rm -fsv $($dc config --services |grep -v -e '^nginx$' -e '^relay$')
+  $dc rm -fsv $($dc config --services | grep -v -E '^(nginx|relay)$')
 else
   # Clean up old stuff and ensure nothing is working while we install/update
   # This is for older versions of on-premise:
@@ -330,7 +330,7 @@ fi
 
 if [[ "$MINIMIZE_DOWNTIME" ]]; then
   # Start the whole setup, except nginx and relay.
-  $dc up -d --remove-orphans $($dc config --services |grep -v -e '^nginx$' -e '^relay$')
+  $dc up -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
   $dc exec nginx service nginx reload
 
   echo "Waiting for Sentry to start..."

--- a/install.sh
+++ b/install.sh
@@ -334,9 +334,8 @@ if [[ "$MINIMIZE_DOWNTIME" ]]; then
   $dc exec nginx service nginx reload
 
   echo "Waiting for Sentry to start..."
-  while [[ "$(curl -m 1 http://localhost:9000/_health/ --silent)" != "ok" ]]; do
-    sleep 0.5
-  done
+  docker run --rm --network="${COMPOSE_PROJECT_NAME}_default" alpine ash \
+    -c 'while [[ "$(wget -T 1 -q -O- http://web:9000/_health/)" != "ok" ]]; do sleep 0.5; done'
 
   # Make sure everything is up. This should only touch relay and nginx
   $dc up -d

--- a/install.sh
+++ b/install.sh
@@ -336,7 +336,7 @@ fi
 if [[ "$MINIMIZE_DOWNTIME" ]]; then
   # Start the whole setup, except nginx and relay.
   $dc up -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
-  $dc exec nginx service nginx reload
+  $dc exec -T nginx service nginx reload
 
   echo "Waiting for Sentry to start..."
   docker run --rm --network="${COMPOSE_PROJECT_NAME}_default" alpine ash \


### PR DESCRIPTION
This continues on the ideas from #607. By "downtime" here I mean "not accepting events" - web, smtp and background processes are out of scope.

This PR adds a `--minimize-downtime` option to install.sh. This options changes the behaviour of the script by:
1. keeping nginx and relay running until the very end,
2. disabling cleanup on exit and failure,
3. explicitly reloading nginx configuration,
4. and starting the whole cluster at the end.

This is a work in progress, and only tested on a local, non-production instance. But the results are promising: no downtime if relay version doesn't change, and only a second when it does. So far this was only tested with a curl loop, so I'm still not sure if Relay flushes the events to Sentry before getting recreated by `$dc up`.
