### PR TITLE
typo: Example configuration comment

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -187,7 +187,7 @@ SENTRY_WEB_PORT = 9000
 SENTRY_WEB_OPTIONS = {
     "http": "%s:%s" % (SENTRY_WEB_HOST, SENTRY_WEB_PORT),
     "protocol": "uwsgi",
-    # This is need to prevent https://git.io/fj7Lw
+    # This is needed in order to prevent https://git.io/fj7Lw
     "uwsgi-socket": None,
     "so-keepalive": True,
     # Keep this between 15s-75s as that's what Relay supports


### PR DESCRIPTION
Fixes a small typo in a example configuration comment