### PR TITLE
ci(github): Reimplement CI in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: test
+on: push
+env:
+  DOCKER_COMPOSE_VERSION: 1.24.1
+jobs:
+  test:
+    runs-on: ubuntu-16.04
+    name: "test"
+    steps:
+
+      - name: Pin docker-compose
+        run: |
+          sudo rm /usr/local/bin/docker-compose
+          curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+          chmod +x docker-compose
+          sudo mv docker-compose /usr/local/bin
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install and test
+        run: |
+          ./install.sh
+          docker-compose run --rm web createuser --superuser --email test@example.com --password test123TEST
+          docker-compose up -d
+          printf "Waiting for Sentry to be up"; timeout 60 bash -c 'until $(curl -Isf -o /dev/null http://localhost:9000); do printf '.'; sleep 0.5; done'
+          ./test.sh
+
+      - name: Inspect failure
+        if: failure()
+        run: |
+          docker-compose ps
+          docker-compose logs


### PR DESCRIPTION
This is a fairly wooden port of the Travis CI config to GitHub actions. Note that this doesn't remove Travis yet. I figure we should run both in parallel for a bit to make sure GitHub Actions is trustworthy. E.g., there might be some caching we want to do to speed up the build, I didn't look into that yet.

Presumably there's some button clicking that needs to happen before this'll run in the main repo. Here's a good run in my fork:

https://github.com/chadwhitacre/onpremise/runs/998127947

And here's a sample bad run in my fork, showing that test failures indeed break the build:

https://github.com/chadwhitacre/onpremise/runs/998137076

Part of #627.