### PR TITLE
Use the custom Nginx access log format

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,6 +17,8 @@ http {
 	'$status $body_bytes_sent "$http_referer" '
 	'"$http_user_agent" "$http_x_forwarded_for"';
 
+	access_log /var/log/nginx/access.log main;
+
 	sendfile on;
 	tcp_nopush on;
 	tcp_nodelay on;


### PR DESCRIPTION
If we are going to define a custom log format, we should probably be using that format.

Fixes #635