### PR TITLE
ci: Disable beacon on CI e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install and test
         run: |
           ./install.sh
-          docker-compose run --rm web createuser --superuser --email test@example.com --password test123TEST
-          docker-compose up -d
-          printf "Waiting for Sentry to be up"; timeout 60 bash -c 'until $(curl -Isf -o /dev/null http://localhost:9000); do printf '.'; sleep 0.5; done'
           ./test.sh
           printf "Testing in-place upgrade"
           ./install.sh --minimize-downtime


### PR DESCRIPTION
This also brings in common pre-test commands into test.sh file.
