### PR TITLE
Allow to limit clickhouse memory usage

### DIFF
--- a/clickhouse/Dockerfile
+++ b/clickhouse/Dockerfile
@@ -1,0 +1,4 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+COPY ./sentry.xml /etc/clickhouse-server/config.d/sentry.xml

--- a/clickhouse/sentry.xml
+++ b/clickhouse/sentry.xml
@@ -1,0 +1,3 @@
+<yandex>
+	<max_server_memory_usage_to_ram_ratio from_env="CLICKHOUSE_MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO" />
+</yandex>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,15 @@ services:
       - 'sentry-secrets:/etc/kafka/secrets'
   clickhouse:
     << : *restart_policy
-    image: 'yandex/clickhouse-server:20.3.9.70'
+    build:
+      context: ./clickhouse
+      args:
+        BASE_IMAGE: 'yandex/clickhouse-server:20.3.9.70'
+    environment:
+      # This limits Clickhouse's memory to 30% of the host memory
+      # If you have high volume and your search return incomplete results
+      # You might want to change this to a higher value (and ensure your host has enough memory)
+      CLICKHOUSE_MAX_SERVER_MEMORY_USAGE_TO_RAM_RATIO: 0.3
     ulimits:
       nofile:
         soft: 262144


### PR DESCRIPTION
Currently Clickhouse memory is not limited, and it requires at least 10G of memory by default.

In this PR, I introduce a way to configure Clickhouse max memory using an environment variable. I chose to set it relative to the host max memory rather than a fixed amount so it will adapt to the size of the host. This is especially useful for people deploying Sentry on hosts with limited memory.

See related discussion in #616 