### PR TITLE
feat(sentry): Disallow internal system IPs

### DIFF
--- a/sentry/sentry.conf.example.py
+++ b/sentry/sentry.conf.example.py
@@ -31,6 +31,7 @@ def get_internal_network():
 
 
 INTERNAL_SYSTEM_IPS = get_internal_network()
+SENTRY_DISALLOWED_IPS = INTERNAL_SYSTEM_IPS
 
 
 DATABASES = {


### PR DESCRIPTION
Set `SENTRY_DISALLOWED_IPS` to `INTERNAL_SYSTEM_IPS` to prevent source and sourcemap requests to internal services in the Docker network.
