### PR TITLE
fix[readme): Don't recommend nginx in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Sentry comes with a cleanup cron job that prunes events older than `90 days` by 
 
 If you'd like to protect your Sentry install with SSL/TLS, there are
 fantastic SSL/TLS proxies like [HAProxy](http://www.haproxy.org/)
-and [Nginx](http://nginx.org/). You'll likely want to add this service to your `docker-compose.yml` file.
+and [Nginx](http://nginx.org/). Our recommendation is running and external Nginx instance or your choice of load balancer that does the TLS termination and more. Read more over at our [productionalizing self-hosted docs](https://develop.sentry.dev/self-hosted/#productionalizing).
 
 ## Updating Sentry
 


### PR DESCRIPTION
Fixes an issue where we recommend adding TLS terminating Nginx into the docker-compose file. This is no longer recommended as we already have an nginx instance there for routing purposes.

Fixes #653.
