### PR TITLE
feat(clickhouse): Reduce max memory usage to 30% of RAM

### DIFF
--- a/clickhouse/config.xml
+++ b/clickhouse/config.xml
@@ -1,0 +1,3 @@
+<yandex>
+    <max_server_memory_usage_to_ram_ratio from_env="MAX_MEMORY_USAGE_RATIO" />
+</yandex>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,11 @@ services:
   clickhouse:
     << : *restart_policy
     image: 'yandex/clickhouse-server:20.3.9.70'
+    environment:
+      # This limits Clickhouse's memory to 30% of the host memory
+      # If you have high volume and your search return incomplete results
+      # You might want to change this to a higher value (and ensure your host has enough memory)
+      MAX_MEMORY_USAGE_RATIO: 0.3
     ulimits:
       nofile:
         soft: 262144
@@ -104,6 +109,10 @@ services:
     volumes:
       - 'sentry-clickhouse:/var/lib/clickhouse'
       - 'sentry-clickhouse-log:/var/log/clickhouse-server'
+      - type: bind
+        read_only: true
+        source: ./clickhouse/config.xml
+        target: /etc/clickhouse-server/config.xml
   snuba-api:
     << : *snuba_defaults
   # Kafka consumer responsible for feeding events into Clickhouse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,11 +97,6 @@ services:
   clickhouse:
     << : *restart_policy
     image: 'yandex/clickhouse-server:20.3.9.70'
-    environment:
-      # This limits Clickhouse's memory to 30% of the host memory
-      # If you have high volume and your search return incomplete results
-      # You might want to change this to a higher value (and ensure your host has enough memory)
-      MAX_MEMORY_USAGE_RATIO: 0.3
     ulimits:
       nofile:
         soft: 262144
@@ -112,7 +107,12 @@ services:
       - type: bind
         read_only: true
         source: ./clickhouse/config.xml
-        target: /etc/clickhouse-server/config.xml
+        target: /etc/clickhouse-server/config.d/sentry.xml
+    environment:
+      # This limits Clickhouse's memory to 30% of the host memory
+      # If you have high volume and your search return incomplete results
+      # You might want to change this to a higher value (and ensure your host has enough memory)
+      MAX_MEMORY_USAGE_RATIO: 0.3
   snuba-api:
     << : *snuba_defaults
   # Kafka consumer responsible for feeding events into Clickhouse


### PR DESCRIPTION
Closes #616, supercedes #651

Adds an option to reduce max memory usage of Clickhouse server. Sets it to 30% of all available RAM as the default.

Co-authored-by: @renchap