### PR TITLE
ci(gha): Fix intermittent test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-16.04
     name: "test"
     steps:
-
       - name: Pin docker-compose
         run: |
           sudo rm /usr/local/bin/docker-compose
@@ -27,6 +26,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install and test
+        env:
+          COMPOSE_PARALLEL_LIMIT: 10
         run: |
           ./install.sh
           ./test.sh


### PR DESCRIPTION
GitHub team pointed us to docker/compose#3586 as the likely root cause and some digging around got us to https://git.io/JUn7p as a potential fix, which we are trying here.
