### PR TITLE
fix(kafka): Reduce Kafka resource usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+mpoomposeversion: '3.4'
 x-restart-policy: &restart_policy
   restart: unless-stopped
 x-sentry-defaults: &sentry_defaults
@@ -84,6 +84,8 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1'
+      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: '1'
+      KAFKA_LOG_RETENTION_HOURS: '24'
       KAFKA_MESSAGE_MAX_BYTES: '50000000' #50MB or bust
       KAFKA_MAX_REQUEST_SIZE: '50000000' #50MB on requests apparently too
       CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-mpoomposeversion: '3.4'
+version: '3.4'
 x-restart-policy: &restart_policy
   restart: unless-stopped
 x-sentry-defaults: &sentry_defaults


### PR DESCRIPTION
Fixes #502 and applies the suggestions from there:

- Number of partitons=1 (from 40)
- Log retention to 1 day (from 7 days)

These settings should be more suited towards the scale this repo is intended for.

NOTE: The partition count change will only affect new installs unless `sentry-kafka` and related volumes are cleaned.
