### PR TITLE
build(docker): Bump min Docker & Compose versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ env:
   DOCKER_COMPOSE_VERSION: 1.24.1
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     name: "test"
     steps:
       - name: Pin docker-compose

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docke
 
 ## Requirements
 
- * Docker 17.05.0+
- * Compose 1.23.0+
+ * Docker 19.03.12+
+ * Compose 1.24.1+
 
 ## Minimum Hardware Requirements:
 

--- a/install.sh
+++ b/install.sh
@@ -11,8 +11,8 @@ dcr="$dc run --rm"
 log_file="sentry_install_log-`date +'%Y-%m-%d_%H-%M-%S'`.txt"
 exec &> >(tee -a "$log_file")
 
-MIN_DOCKER_VERSION='17.05.0'
-MIN_COMPOSE_VERSION='1.23.0'
+MIN_DOCKER_VERSION='19.03.12'
+MIN_COMPOSE_VERSION='1.24.1'
 MIN_RAM=2400 # MB
 
 SENTRY_CONFIG_PY='sentry/sentry.conf.py'


### PR DESCRIPTION
We need `docker-compose ps -a` for CI so we were already using 1.24.1, this aligns the rest with that.

For Docker, there are a bunch of network-related fixes in 19.03.12 and prior (DNS fallback and IPv6 advertising) that we'd like to have to see if they are going to fix some reported connectivity issues w/ onpremise.
