### PR TITLE
fix(redis): Increase file descriptors to 10032

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,11 @@ services:
     image: 'redis:5.0-alpine'
     volumes:
       - 'sentry-redis:/data'
+    ulimits:
+      nofile:
+        soft: 10032
+        hard: 10032
+   
   postgres:
     << : *restart_policy
     image: 'postgres:9.6'


### PR DESCRIPTION
@xbenjii reported the following error on #629:
>You requested maxclients of 10000 requiring at least 10032 max file descriptors.

Increasing this limit by default makes sense to make Redis more available to heaveier loads.
