### PR TITLE
fix(kafka): Enable auto topic creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       KAFKA_LOG_RETENTION_HOURS: '24'
       KAFKA_MESSAGE_MAX_BYTES: '50000000' # 50MB or bust
       KAFKA_MAX_REQUEST_SIZE: '50000000' # 50MB on requests apparently too
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true' # We need this for topic used outside of Snuba (attachments etc.)
+      KAFKA_PRODUCER_AUTO_CREATE_TOPICS: 'client-side' # We need this for topic used outside of Snuba (attachments etc.)
       CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
       KAFKA_LOG4J_LOGGERS: 'kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,kafka.zookeeper=WARN,state.change.logger=WARN'
       KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,6 @@ services:
       KAFKA_LOG_RETENTION_HOURS: '24'
       KAFKA_MESSAGE_MAX_BYTES: '50000000' # 50MB or bust
       KAFKA_MAX_REQUEST_SIZE: '50000000' # 50MB on requests apparently too
-      KAFKA_PRODUCER_AUTO_CREATE_TOPICS: 'client-side' # We need this for topic used outside of Snuba (attachments etc.)
       CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
       KAFKA_LOG4J_LOGGERS: 'kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,kafka.zookeeper=WARN,state.change.logger=WARN'
       KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,9 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1'
       KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: '1'
       KAFKA_LOG_RETENTION_HOURS: '24'
-      KAFKA_MESSAGE_MAX_BYTES: '50000000' #50MB or bust
-      KAFKA_MAX_REQUEST_SIZE: '50000000' #50MB on requests apparently too
+      KAFKA_MESSAGE_MAX_BYTES: '50000000' # 50MB or bust
+      KAFKA_MAX_REQUEST_SIZE: '50000000' # 50MB on requests apparently too
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true' # We need this for topic used outside of Snuba (attachments etc.)
       CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
       KAFKA_LOG4J_LOGGERS: 'kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,kafka.zookeeper=WARN,state.change.logger=WARN'
       KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'

--- a/install.sh
+++ b/install.sh
@@ -243,7 +243,7 @@ fi
 # We need this for topic used outside of Snuba (attachments etc.)
 echo "Enabling auto topic creation for Kafka..."
 $dc up -d kafka
-$dcr kafka kafka-configs --bootstrap-server kafka:9002 --command-config config.properties --entity-type brokers --entity-default --alter --add-config auto.create.topics.enable=true
+$dcr kafka kafka-configs --bootstrap-server kafka:9092 --command-config config.properties --entity-type brokers --entity-default --alter --add-config auto.create.topics.enable=true
 echo ""
 
 echo "Bootstrapping and migrating Snuba..."

--- a/install.sh
+++ b/install.sh
@@ -240,6 +240,12 @@ if [[ "$ZOOKEEPER_SNAPSHOT_FOLDER_EXISTS" -eq 1 ]]; then
   fi
 fi
 
+# We need this for topic used outside of Snuba (attachments etc.)
+echo "Enabling auto topic creation for Kafka..."
+$dc up -d kafka
+$dcr kafka kafka-configs --bootstrap-server kafka:9002 --command-config config.properties --entity-type brokers --entity-default --alter --add-config auto.create.topics.enable=true
+echo ""
+
 echo "Bootstrapping and migrating Snuba..."
 $dcr snuba-api bootstrap --no-migrate --force
 $dcr snuba-api migrations migrate --force


### PR DESCRIPTION
We don't explicitly create topics outside of Snuba which causes issues with Sentry<->Relay-only topics like `ingest-attachments`. Enabling this will save us from any future troubles around forgotten kafka topics and maintaining a separate list here on onpremise.

Fixes #683.
