### PR TITLE
fix(py3): Make event ingestion test more robust

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -74,7 +74,7 @@ done
 # Set up initial/required settings (InstallWizard request)
 sentry_api_request "internal/options/?query=is:required" -X PUT --data '{"mail.use-tls":false,"mail.username":"","mail.port":25,"system.admin-email":"ben@byk.im","mail.password":"","mail.from":"root@localhost","system.url-prefix":"'"$SENTRY_TEST_HOST"'","auth.allow-registration":false,"beacon.anonymous":true}' > /dev/null
 
-SENTRY_DSN=$(sentry_api_request "projects/sentry/internal/keys/" | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "public" { print $4; exit; }')
+SENTRY_DSN=$(sentry_api_request "projects/sentry/internal/keys/" | awk 'BEGIN { RS=",|:{\n"; FS="\""; } $2 == "public" && $4 ~ "^http" { print $4; exit; }')
 # We ignore the protocol and the host as we already know those
 DSN_PIECES=(`echo $SENTRY_DSN | sed -ne 's|^https\?://\([0-9a-z]\+\)@[^/]\+/\([0-9]\+\)$|\1\n\2|p'`)
 SENTRY_KEY=${DSN_PIECES[0]}


### PR DESCRIPTION
We were relying on the public DSN field coming first from the API and with Python 3, that's not the case to the tests were failing. This PR makes DSN extraction a bit more robust while still avoiding a full-fledged JSON parser.

Unblocks getsentry/sentry#21126