### PR TITLE
fix(install): Increase stop timeout to 60 seconds

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ MIN_RAM=2400 # MB
 
 # Increase the default 10 second SIGTERM timeout
 # to ensure celery queues are properly drained 
-# between upgrades as event formats may change across
+# between upgrades as task signatures may change across
 # versions
 STOP_TIMEOUT=60 # seconds
 SENTRY_CONFIG_PY='sentry/sentry.conf.py'


### PR DESCRIPTION
This is to ensure clean shutdown of Celery, with fully drained queues. This is needed as versions may change the event format and not be backwards compatible. FWIW this is a hacky workaround without a strong guarantee that the queues will be empty. Ideally we'd shutdown everything first, spin up the workers and check for queues being drained every second or so.
