### PR TITLE
fix(install): Disable the script on git-bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+if [ -x ${MSYSTEM+x} ]; then
+  echo "Seems like you ar using Git-Bash which is not supported. Please use WSL instead.";
+  exit 1
+fi
+
 # Read .env for default values with a tip o' the hat to https://stackoverflow.com/a/59831605/90297
 t=$(mktemp) && export -p > "$t" && set -a && . ./.env && set +a && . "$t" && rm "$t" && unset t
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [ -n ${MSYSTEM+x} ]; then
+if [[ -n "$MSYSTEM" ]]; then
   echo "Seems like you ar using Git-Bash which is not supported. Please use WSL instead.";
   exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [ -z ${MSYSTEM+x} ]; then
+if [ -n ${MSYSTEM+x} ]; then
   echo "Seems like you ar using Git-Bash which is not supported. Please use WSL instead.";
   exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-if [ -x ${MSYSTEM+x} ]; then
+if [ -z ${MSYSTEM+x} ]; then
   echo "Seems like you ar using Git-Bash which is not supported. Please use WSL instead.";
   exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [[ -n "$MSYSTEM" ]]; then
-  echo "Seems like you ar using Git-Bash which is not supported. Please use WSL instead.";
+  echo "Seems like you are using an MSYS2-based system (such as Git Bash) which is not supported. Please use WSL instead.";
   exit 1
 fi
 


### PR DESCRIPTION
We kept getting issue reports that we traced down to `git-bash` which doesn't seem to play nice with Docker for Windows with bind mounts. This PR uses the existence of `$MSYSTEM` to detect `git-bash` and exit early with a relevant message.
