### PR TITLE
fix(sentry): Pass SENTRY_EVENT_RETENTION_DAYS to sentry services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ x-sentry-defaults: &sentry_defaults
   environment:
     SENTRY_CONF: '/etc/sentry'
     SNUBA: 'http://snuba-api:1218'
+    SENTRY_EVENT_RETENTION_DAYS: 
   volumes:
     - 'sentry-data:/data'
     - './sentry:/etc/sentry'


### PR DESCRIPTION
We are already referencing this env var here:

https://github.com/getsentry/onpremise/blob/19f4561a9e2abe32dc5eb5a03a332b50f2265b4b/sentry/sentry.conf.example.py#L62-L64

@lynnagara should we be passing this to Snuba and any other services too?