### PR TITLE
fix(clickhouse): set enable_mixed_granularity_parts to enabled

### DIFF
--- a/clickhouse/config.xml
+++ b/clickhouse/config.xml
@@ -4,4 +4,7 @@
         <level>information</level>
         <console>1</console>
     </logger>
+    <merge_tree>
+        <enable_mixed_granularity_parts>1</enable_mixed_granularity_parts>
+    </merge_tree>
 </yandex>


### PR DESCRIPTION
I've noticed clickhouse complaining about this missing setting, which stopped clickhouse from starting up with version 20.3.9.70

/cc @BYK 

Related to https://github.com/getsentry/onpremise/issues/726