### PR TITLE
fix(snuba): Pass SENTRY_EVENT_RETENTION_DAYS to Snuba instances too

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ x-sentry-defaults: &sentry_defaults
   environment:
     SENTRY_CONF: '/etc/sentry'
     SNUBA: 'http://snuba-api:1218'
+    # Leaving the value empty to just pass whatever is set
+    # on the host system (or in the .env file)
     SENTRY_EVENT_RETENTION_DAYS:
   volumes:
     - 'sentry-data:/data'
@@ -43,6 +45,8 @@ x-snuba-defaults: &snuba_defaults
     REDIS_HOST: redis
     UWSGI_MAX_REQUESTS: '10000'
     UWSGI_DISABLE_LOGGING: 'true'
+    # Leaving the value empty to just pass whatever is set
+    # on the host system (or in the .env file)
     SENTRY_EVENT_RETENTION_DAYS:
 services:
   smtp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ x-sentry-defaults: &sentry_defaults
   environment:
     SENTRY_CONF: '/etc/sentry'
     SNUBA: 'http://snuba-api:1218'
-    SENTRY_EVENT_RETENTION_DAYS: 
+    SENTRY_EVENT_RETENTION_DAYS:
   volumes:
     - 'sentry-data:/data'
     - './sentry:/etc/sentry'
@@ -43,6 +43,7 @@ x-snuba-defaults: &snuba_defaults
     REDIS_HOST: redis
     UWSGI_MAX_REQUESTS: '10000'
     UWSGI_DISABLE_LOGGING: 'true'
+    SENTRY_EVENT_RETENTION_DAYS:
 services:
   smtp:
     << : *restart_policy


### PR DESCRIPTION
Follow up on #754. Depends on getsentry/snuba#1526.
