### PR TITLE
Lock closed issues/PRs via 3rd-party action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,15 @@
+name: 'Lock closed issues and pull requests'
+on:
+  schedule:
+    - cron: '0 * * * *'
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: 15
+          issue-lock-reason: ''
+          pr-lock-inactive-days: 15
+          pr-lock-reason: ''

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,7 +1,7 @@
 name: 'Lock closed issues and pull requests'
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '*/5 * * * *'
 jobs:
   lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes https://app.asana.com/0/1199602781063150/1198192573081731.

Action does [appear](https://github.com/dessant/lock-threads/blob/63786a6c74ee3cfc4584f36de4360305c55e5126/src/index.js#L111-L119) to limit to 50 issues per run as [documented](https://github.com/dessant/lock-threads#why-are-only-some-issues-and-pull-requests-processed). We have ~800 closed issues in this repo, so that's ~16 clock ticks, rec is to start w/ hourly, then drop to daily (via additional yml commit) once initial backlog is processed.

[Action](https://github.com/dessant/lock-threads) has 150 stars (not a _lot_ but not a little for something like this) and the [author](https://github.com/dessant) seems legit. I gave the code a skim and did not see anything obviously malicious. MIT.