### PR TITLE
ci(release): Move to getsentry/publish for releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: "0.10.0"
+minVersion: "0.14.0"
 github:
   owner: getsentry
   repo: onpremise

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,9 @@ on:
       version:
         description: Version to release (optional)
         required: false
-      skip_prepare:
-        description: Skip preparation step (assume a release branch is ready)
-        required: false
-        default: false
-      dry_run:
-        description: Do not actually cut the release
-        required: false
-        default: false
       force:
-        description: Force the release, bypassing the 'release-blocker' issue killswitch
+        description: Force a release even when there are release-blockers (optional)
         required: false
-        default: false
   schedule:
     # We want the release to be at 10 or 11am Pacific Time
     # We also make this an hour after all others such as Sentry,
@@ -34,29 +25,22 @@ jobs:
           force: ${{ github.event.inputs.force }}
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GH_SENTRY_BOT_PAT }}
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
       - uses: getsentry/craft@master
         name: Craft Prepare
-        if: ${{ !github.event.inputs.skip_prepare }}
         with:
           action: prepare
           version: ${{ env.RELEASE_VERSION }}
-      # Wait until the builds start. Craft should do this automatically
-      # but it is broken now.
-      - run: sleep 10
-      - uses: getsentry/craft@master
-        name: Craft Publish
+      - name: Request publish
+        if: success()
+        uses: actions/github-script@v3
         with:
-          action: publish
-          version: ${{ env.RELEASE_VERSION }}
-          no_merge: '--no-merge'
-        env:
-          DRY_RUN: ${{ github.event.inputs.dry_run }}
-      # We need this additional step because we don't merge release branches into master to
-      # always keep it on nightlies
-      - id: bump-license-date
-        name: Bump license change date
-        if: ${{ !github.event.inputs.dry_run && !github.event.inputs.version }}
-        run: |
-          sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
-          git diff --quiet || git commit -anm 'license: Update BSL change date' && git push
+          github-token: ${{ secrets.GH_RELEASE_PAT }}
+          script: |
+            const repoInfo = context.repo;
+            await github.issues.create({
+              owner: repoInfo.owner,
+              repo: 'publish',
+              title: `publish: ${repoInfo.repo}@${process.env.RELEASE_VERSION}`,
+            });

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -7,7 +7,7 @@ cd $SCRIPT_DIR/..
 OLD_VERSION="$1"
 NEW_VERSION="$2"
 
-SYMBOLICATOR_VERSION=$(curl -s "https://api.github.com/repos/getsentry/symbolicator/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')
+SYMBOLICATOR_VERSION=${SYMBOLICATOR_VERSION:-$(curl -s "https://api.github.com/repos/getsentry/symbolicator/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')}
 
 sed -i -e "s/^SYMBOLICATOR_IMAGE=\([^:]\+\):.\+\$/SYMBOLICATOR_IMAGE=\1:$SYMBOLICATOR_VERSION/" .env
 sed -i -e "s/^\(SENTRY\|SNUBA\|RELAY\)_IMAGE=\([^:]\+\):.\+\$/\1_IMAGE=\2:$NEW_VERSION/" .env

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+# Bring master back to nightlies after merge from release branch
+
+SYMBOLICATOR_VERSION=nightly
+
+./scripts/bump-version.sh '' 'nightly'
+git diff --quiet || git commit -anm 'build: Set master version to nightly' && git push

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -6,7 +6,5 @@ cd $SCRIPT_DIR/..
 
 # Bring master back to nightlies after merge from release branch
 
-SYMBOLICATOR_VERSION=nightly
-
-./scripts/bump-version.sh '' 'nightly'
+SYMBOLICATOR_VERSION=nightly ./scripts/bump-version.sh '' 'nightly'
 git diff --quiet || git commit -anm 'build: Set master version to nightly' && git push


### PR DESCRIPTION
A copy of getsentry/sentry#22657 with fixes included.

That said this one is a bit different. We used to use the extra option `no-merge` when publishing to keep the release branches and also keep master on nightly versions. If we want to keep this, we need to add per-project overrides to getsentry/publish which would increase complexity at this early stage for this fringe case. Instead, I opted to follow what getsentry/sentry does: merge but then immediately after that update the version.