### PR TITLE
Futz with action pin syntax

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,7 +6,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@63786a6c74ee3cfc4584f36de4360305c55e5127
+      - uses: dessant/lock-threads@63786a6
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: 15


### PR DESCRIPTION
[Failing](https://github.com/getsentry/onpremise/runs/1571980788?check_suite_focus=true#step:1:14) with:

> Download action repository 'dessant/lock-threads@63786a6c74ee3cfc4584f36de4360305c55e5127'
Error: An action could not be found at the URI 'https://api.github.com/repos/dessant/lock-threads/tarball/63786a6c74ee3cfc4584f36de4360305c55e5127'

Will this convince actions to parse as SHA?