### PR TITLE
meta: Install stalebot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,20 +14,34 @@ jobs:
           days-before-close: 7
           only-labels: ""
           operations-per-run: 100
-          remove-stale-when-updated: false
+          remove-stale-when-updated: true
           debug-only: false
           ascending: false
 
-          exempt-issue-labels: "Triage: Accepted"
-          stale-issue-label: "Triage: Stale"
-          stale-issue-message: "This message is required, but you shouldn't see it."
-          skip-stale-issue-message: true
+          exempt-issue-labels: "Status: Accepted"
+          stale-issue-label: "Status: Stale"
+          stale-issue-message: |-
+            This issue has gone three weeks without activity. In another week, I will close it.
+
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `State: Accepted`, I will leave it alone entirely.
+
+            ----
+
+            "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
+          skip-stale-issue-message: false
           close-issue-label: ""
           close-issue-message: ""
 
-          exempt-pr-labels: "Triage: Accepted"
-          stale-pr-label: "Triage: Stale"
-          stale-pr-message: "This message is required, but you shouldn't see it."
-          skip-stale-pr-message: true
+          exempt-pr-labels: "Status: Accepted"
+          stale-pr-label: "Status: Stale"
+          stale-pr-message: |-
+            This pull request has gone three weeks without activity. In another week, I will close it.
+
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `State: Accepted`, I will leave it alone entirely.
+
+            ----
+
+            "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
+          skip-stale-pr-message: false
           close-pr-label:
           close-pr-message: ""

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
           stale-issue-message: |-
             This issue has gone three weeks without activity. In another week, I will close it.
 
-            But! If you comment or otherwise update it, I will reset the clock, and if you label it `State: Accepted`, I will leave it alone entirely.
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Accepted`, I will leave it alone entirely.
 
             ----
 
@@ -37,7 +37,7 @@ jobs:
           stale-pr-message: |-
             This pull request has gone three weeks without activity. In another week, I will close it.
 
-            But! If you comment or otherwise update it, I will reset the clock, and if you label it `State: Accepted`, I will leave it alone entirely.
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Accepted`, I will leave it alone entirely.
 
             ----
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
           stale-issue-message: |-
             This issue has gone three weeks without activity. In another week, I will close it.
 
-            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Accepted`, I will leave it alone entirely.
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Accepted`, I will leave it alone ... forever!
 
             ----
 
@@ -37,7 +37,7 @@ jobs:
           stale-pr-message: |-
             This pull request has gone three weeks without activity. In another week, I will close it.
 
-            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Accepted`, I will leave it alone entirely.
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Accepted`, I will leave it alone ... forever!
 
             ----
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: 'close stale issues/PRs'
+on:
+  schedule:
+    - cron: '* */6 * * *'
+  workflow_dispatch:
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@87c2b794b9b47a9bec68ae03c01aeb572ffebdb1
+        with:
+          repo-token: ${{ github.token }}
+          days-before-stale: 21
+          days-before-close: 7
+          only-labels: ""
+          operations-per-run: 100
+          remove-stale-when-updated: false
+          debug-only: false
+          ascending: false
+
+          exempt-issue-labels: "Triage: Accepted"
+          stale-issue-label: "Triage: Stale"
+          stale-issue-message: "This message is required, but you shouldn't see it."
+          skip-stale-issue-message: true
+          close-issue-label: ""
+          close-issue-message: ""
+
+          exempt-pr-labels: "Triage: Accepted"
+          stale-pr-label: "Triage: Stale"
+          stale-pr-message: "This message is required, but you shouldn't see it."
+          skip-stale-pr-message: true
+          close-pr-label:
+          close-pr-message: ""


### PR DESCRIPTION
https://app.asana.com/0/1199602781063150/1198192573081727

- Labels un-triaged issues with `Status: Stale` after three weeks of inactivity.
- Closes issues so labeled after one more week of inactivity.
- Use `Status: Accepted` to hold open indefinitely.