### PR TITLE
ci(release): Enable the CalVer flag for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
+          calver: true


### PR DESCRIPTION
We need this for automated version numbers
