### PR TITLE
Bump RAM requirement in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,8 @@ exec &> >(tee -a "$log_file")
 
 MIN_DOCKER_VERSION='19.03.6'
 MIN_COMPOSE_VERSION='1.24.1'
-MIN_RAM=8000 # MB
+MIN_RAM_HARD=4000 # MB
+MIN_RAM_SOFT=8000 # MB
 
 # Increase the default 10 second SIGTERM timeout
 # to ensure celery queues are properly drained
@@ -121,9 +122,11 @@ if [[ "$(ver $COMPOSE_VERSION)" -lt "$(ver $MIN_COMPOSE_VERSION)" ]]; then
   exit 1
 fi
 
-if [[ "$RAM_AVAILABLE_IN_DOCKER" -lt "$MIN_RAM" ]]; then
-  echo "FAIL: Expected minimum RAM available to Docker to be $MIN_RAM MB but found $RAM_AVAILABLE_IN_DOCKER MB"
+if [[ "$RAM_AVAILABLE_IN_DOCKER" -lt "$MIN_RAM_HARD" ]]; then
+  echo "FAIL: Required minimum RAM available to Docker is $MIN_RAM_HARD MB, found $RAM_AVAILABLE_IN_DOCKER MB"
   exit 1
+elif [[ "$RAM_AVAILABLE_IN_DOCKER" -lt "$MIN_RAM_SOFT" ]]; then
+  echo "WARN: Recommended minimum RAM available to Docker is $MIN_RAM_SOFT MB, found $RAM_AVAILABLE_IN_DOCKER MB"
 fi
 
 #SSE4.2 required by Clickhouse (https://clickhouse.yandex/docs/en/operations/requirements/)

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ exec &> >(tee -a "$log_file")
 
 MIN_DOCKER_VERSION='19.03.6'
 MIN_COMPOSE_VERSION='1.24.1'
-MIN_RAM=2400 # MB
+MIN_RAM=8000 # MB
 
 # Increase the default 10 second SIGTERM timeout
 # to ensure celery queues are properly drained


### PR DESCRIPTION
In #787 we decided to up the minimum RAM requirement from 2.4 to 8 GB, handled the README in 2dadbda1cc44e5a9a1c1a84f6dd0306258f17a47, now for `install.sh` ... where it really matters. :)

h/t @AlexanderRydberg