### PR TITLE
Source install/geoip.sh, to work in more envs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,7 @@ fi
 # Read .env for default values with a tip o' the hat to https://stackoverflow.com/a/59831605/90297
 t=$(mktemp) && export -p > "$t" && set -a && . ./.env && set +a && . "$t" && rm "$t" && unset t
 
-dc="docker-compose --no-ansi"
-dcr="$dc run --rm"
+source ./install/docker-aliases.sh
 
 # Thanks to https://unix.stackexchange.com/a/145654/108960
 log_file="sentry_install_log-`date +'%Y-%m-%d_%H-%M-%S'`.txt"
@@ -329,7 +328,7 @@ if [[ ! -f "$RELAY_CREDENTIALS_JSON" ]]; then
 fi
 
 
-./install/geoip.sh
+source ./install/geoip.sh
 
 
 if [[ "$MINIMIZE_DOWNTIME" ]]; then

--- a/install/docker-aliases.sh
+++ b/install/docker-aliases.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+dc="docker-compose --no-ansi"
+dcr="$dc run --rm"

--- a/install/geoip.sh
+++ b/install/geoip.sh
@@ -2,9 +2,7 @@
 
 if [ ! -f 'install.sh' ]; then echo 'Where are you?'; exit 1; fi
 
-dc="docker-compose --no-ansi"
-dcr="$dc run --rm"
-
+source ./install/docker-aliases.sh
 
 install_geoip() {
   local mmdb='geoip/GeoLite2-City.mmdb'


### PR DESCRIPTION
This works better in, e.g., GCE.

DRY up dc/dcr aliases in the process.