### PR TITLE
fix: Enable experimental reqwest library for relay

### DIFF
--- a/relay/config.example.yml
+++ b/relay/config.example.yml
@@ -11,3 +11,5 @@ processing:
     - {name: "message.max.bytes", value: 50000000} #50MB or bust
   redis: redis://redis:6379
   geoip_path: "/geoip/GeoLite2-City.mmdb"
+http:
+  _client: "reqwest"


### PR DESCRIPTION
As mentioned on the forum, this is stable enough and solves a big, ongoing issue with relay unable to connect to any internal services: https://forum.sentry.io/t/relay-errors-in-fresh-new-on-premise-install/9804/24

Should fix #771.