### PR TITLE
fix: Fix Py2 warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
 env:
   DOCKER_COMPOSE_VERSION: 1.24.1
+defaults:
+  shell: bash
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,8 @@ on:
 env:
   DOCKER_COMPOSE_VERSION: 1.24.1
 defaults:
-  shell: bash
+  run:
+    shell: bash
 jobs:
   test:
     strategy:

--- a/install.sh
+++ b/install.sh
@@ -351,4 +351,7 @@ else
   echo ""
 fi
 
+
+echo 'CHEESE'
 source ./install/py2-warning.sh
+echo 'BREAD'

--- a/install.sh
+++ b/install.sh
@@ -351,7 +351,4 @@ else
   echo ""
 fi
 
-
-echo 'CHEESE'
 source ./install/py2-warning.sh
-echo 'BREAD'

--- a/install/geoip.sh
+++ b/install/geoip.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ ! -f 'install.sh' ]; then echo 'Where are you?'; exit 1; fi
+if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 
 source ./install/docker-aliases.sh
 
@@ -26,7 +26,7 @@ install_geoip() {
     echo "IP address geolocation is configured for updates."
     echo "Updating IP address geolocation database ... "
     $dcr geoipupdate
-    if [ $? -gt 0 ]; then
+    if [[ $? -gt 0 ]]; then
       result='Error'
     fi
     echo "$result updating IP address geolocation database."

--- a/install/geoip.sh
+++ b/install/geoip.sh
@@ -25,8 +25,7 @@ install_geoip() {
   else
     echo "IP address geolocation is configured for updates."
     echo "Updating IP address geolocation database ... "
-    $dcr geoipupdate
-    if [[ $? -gt 0 ]]; then
+    if ! $dcr geoipupdate; then
       result='Error'
     fi
     echo "$result updating IP address geolocation database."

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -2,8 +2,11 @@
 
 if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 
-IS_PYTHON2=$(docker run --entrypoint python sentry-onpremise-local --version | grep -c 'Python 2' || [[ $? == 1 ]])
-if [[ "$IS_PYTHON2" == 1 ]]; then
+source ./install/docker-aliases.sh
+
+# Note the stderr>stdout redirection because Python thinks `--version` should
+# be on stderr: https://stackoverflow.com/a/31715011/90297
+if $dcr --no-deps --entrypoint python web --version 2>&1 | grep -q 'Python 2'; then
   WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -5,16 +5,16 @@ if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 source ./install/docker-aliases.sh
 
 if $dcr --no-deps --entrypoint python web --version | grep -q 'Python 2'; then
-  read -r -d '' WARNING_TEXT <<'EOW'
+  WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |
 | || |   \ \  /\  / / / _ \      | |__) |    |   \ | |    | |    |   \ | | / .'   \_| | || |
 | || |    \ \/  \/ / / ___ \     |  __ /     | |\ \| |    | |    | |\ \| | | |   ____ | || |
-|_||_|     \  /\  /_/ /   \ \_  _| |  \ \_  _| |_\   |_  _| |_  _| |_\   |_\ `.___]  ||_||_|
-(_)(_)      \/  \/|____| |____||____| |___||_____|\____||_____||_____|\____|`._____.' (_)(_)
-EOW
+|_||_|     \  /\  /_/ /   \ \_  _| |  \ \_  _| |_\   |_  _| |_  _| |_\   |_\ \`.___]  ||_||_|
+(_)(_)      \/  \/|____| |____||____| |___||_____|\____||_____||_____|\____|\`._____.' (_)(_)
+
+"
   echo "$WARNING_TEXT"
-  echo ''
   echo '-----------------------------------------------------------'
   echo 'You are using Sentry with Python 2, which is deprecated.'
   echo 'Sentry 21.1 will be the last version with Python 2 support.'

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -4,7 +4,7 @@ if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 
 source ./install/docker-aliases.sh
 
-if $dcr --no-deps --entrypoint python web --version | grep -q 'Python 2' then
+if $dcr --no-deps --entrypoint python web --version | grep -q 'Python 2'; then
   read -r -d '' WARNING_TEXT <<'EOW'
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -4,7 +4,7 @@ if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 
 source ./install/docker-aliases.sh
 
-if $dcr --no-deps --entrypoint python web --version | grep -q 'Python 2'; then
+if $dcr --no-deps --entrypoint python web --version | grep -q 'Python 3'; then
   WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -2,9 +2,7 @@
 
 if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 
-source ./install/docker-aliases.sh
-
-IS_PYTHON2=$($dcr --no-deps --entrypoint python web --version | grep -c 'Python 2' || [[ $? == 1 ]])
+IS_PYTHON2=$(docker run --entrypoint python sentry-onpremise-local --version | grep -c 'Python 2' || [[ $? == 1 ]])
 if [[ "$IS_PYTHON2" == 1 ]]; then
   WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -4,8 +4,8 @@ if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 
 source ./install/docker-aliases.sh
 
-SENTRY_PYTHON_VERSION=$($dcr --no-deps --entrypoint python web --version)
-if echo "$SENTRY_PYTHON_VERSION" | grep -q 'Python 2'; then
+IS_PYTHON2=$($dcr --no-deps --entrypoint python web --version | grep -c 'Python 2' || [[ $? == 1 ]])
+if [[ "$IS_PYTHON2" == 1]]; then
   WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -5,7 +5,7 @@ if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 source ./install/docker-aliases.sh
 
 IS_PYTHON2=$($dcr --no-deps --entrypoint python web --version | grep -c 'Python 2' || [[ $? == 1 ]])
-if [[ "$IS_PYTHON2" == 1]]; then
+if [[ "$IS_PYTHON2" == 1 ]]; then
   WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
-echo "A"
+
 source ./install/docker-aliases.sh
-echo "B"
-if echo "C" && $dcr --no-deps --entrypoint python web --version | grep -q 'Python 2'; then
-echo "D";
+
+SENTRY_PYTHON_VERSION=$($dcr --no-deps --entrypoint python web --version)
+if echo "$SENTRY_PYTHON_VERSION" | grep -q 'Python 2'; then
   WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |
@@ -15,9 +15,7 @@ echo "D";
 (_)(_)      \/  \/|____| |____||____| |___||_____|\____||_____||_____|\____|\`._____.' (_)(_)
 
 "
-echo "E"
   echo "$WARNING_TEXT"
-echo "F"
   echo '-----------------------------------------------------------'
   echo 'You are using Sentry with Python 2, which is deprecated.'
   echo 'Sentry 21.1 will be the last version with Python 2 support.'

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -7,7 +7,7 @@ source ./install/docker-aliases.sh
 # Note the stderr>stdout redirection because Python thinks `--version` should
 # be on stderr: https://stackoverflow.com/a/31715011/90297
 if $dcr --no-deps --entrypoint python web --version 2>&1 | grep -q 'Python 2'; then
-  WARNING_TEXT="
+  echo "
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |
 | || |   \ \  /\  / / / _ \      | |__) |    |   \ | |    | |    |   \ | | / .'   \_| | || |
@@ -16,7 +16,6 @@ if $dcr --no-deps --entrypoint python web --version 2>&1 | grep -q 'Python 2'; t
 (_)(_)      \/  \/|____| |____||____| |___||_____|\____||_____||_____|\____|\`._____.' (_)(_)
 
 "
-  echo "$WARNING_TEXT"
   echo '-----------------------------------------------------------'
   echo 'You are using Sentry with Python 2, which is deprecated.'
   echo 'Sentry 21.1 will be the last version with Python 2 support.'

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
-if [ ! -f 'install.sh' ]; then echo 'Where are you?'; exit 1; fi
+if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 
 source ./install/docker-aliases.sh
 
-IS_PYTHON2=$($dcr --no-deps --entrypoint python web --version | grep 'Python 2')
-if [[ -n "$IS_PYTHON2" ]]; then
+if $dcr --no-deps --entrypoint python web --version | grep -q 'Python 2' then
   read -r -d '' WARNING_TEXT <<'EOW'
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -4,7 +4,7 @@ if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 
 source ./install/docker-aliases.sh
 
-if $dcr --no-deps --entrypoint python web --version | grep -q 'Python 3'; then
+if $dcr --no-deps --entrypoint python web --version | grep -q 'Python 2'; then
   WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -4,21 +4,19 @@ if [ ! -f 'install.sh' ]; then echo 'Where are you?'; exit 1; fi
 
 source ./install/docker-aliases.sh
 
-py2_warning() {
-  local IS_PYTHON2=$($dcr --no-deps --entrypoint python web --version | grep 'Python 2')
-  if [[ -n "$IS_PYTHON2" ]]; then
-    cat <<"EOW"
+IS_PYTHON2=$($dcr --no-deps --entrypoint python web --version | grep 'Python 2')
+if [[ -n "$IS_PYTHON2" ]]; then
+  read -r -d '' WARNING_TEXT <<'EOW'
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |
 | || |   \ \  /\  / / / _ \      | |__) |    |   \ | |    | |    |   \ | | / .'   \_| | || |
 | || |    \ \/  \/ / / ___ \     |  __ /     | |\ \| |    | |    | |\ \| | | |   ____ | || |
 |_||_|     \  /\  /_/ /   \ \_  _| |  \ \_  _| |_\   |_  _| |_  _| |_\   |_\ `.___]  ||_||_|
 (_)(_)      \/  \/|____| |____||____| |___||_____|\____||_____||_____|\____|`._____.' (_)(_)
-
 EOW
-    echo 'You are using Sentry with Python 2, which is deprecated.'
-    echo 'Sentry 21.1 will be the last version with Python 2 support.'
-  fi
-}
-
-py2_warning
+  echo "$WARNING_TEXT"
+  echo ''
+  echo '-----------------------------------------------------------'
+  echo 'You are using Sentry with Python 2, which is deprecated.'
+  echo 'Sentry 21.1 will be the last version with Python 2 support.'
+fi

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -5,8 +5,9 @@ if [ ! -f 'install.sh' ]; then echo 'Where are you?'; exit 1; fi
 source ./install/docker-aliases.sh
 
 py2_warning() {
-    if [[ -n $($dcr --no-deps --entrypoint python web --version | grep 'Python 2') ]]; then
-      cat <<"EOW"
+  local IS_PYTHON2=$($dcr --no-deps --entrypoint python web --version | grep 'Python 2')
+  if [[ -n "$IS_PYTHON2" ]]; then
+    cat <<"EOW"
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |
 | || |   \ \  /\  / / / _ \      | |__) |    |   \ | |    | |    |   \ | | / .'   \_| | || |
@@ -15,13 +16,9 @@ py2_warning() {
 (_)(_)      \/  \/|____| |____||____| |___||_____|\____||_____||_____|\____|`._____.' (_)(_)
 
 EOW
-      echo 'You are using Sentry with Python 2, which is deprecated.'
-      echo 'Sentry 21.1 will be the last version with Python 2 support.'
-    fi
+    echo 'You are using Sentry with Python 2, which is deprecated.'
+    echo 'Sentry 21.1 will be the last version with Python 2 support.'
+  fi
 }
 
 py2_warning
-# Run a simple command that would exit with code 0 so the calling script won't think
-# there was a failure in this script. (otherwise it fails when Python 2 is *NOT* detected)
-# as the exit code for the `grep` call will be `-1` indicating no match found.
-echo ''

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -2,9 +2,7 @@
 
 if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
 
-source ./install/docker-aliases.sh
-
-if $dcr --no-deps --entrypoint python web --version | grep -q 'Python 2'; then
+if docker-compose --no-ansi run --rm --no-deps --entrypoint python web --version | grep -q 'Python 2'; then
   WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |

--- a/install/py2-warning.sh
+++ b/install/py2-warning.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
 if [[ ! -f 'install.sh' ]]; then echo 'Where are you?'; exit 1; fi
-
-if docker-compose --no-ansi run --rm --no-deps --entrypoint python web --version | grep -q 'Python 2'; then
+echo "A"
+source ./install/docker-aliases.sh
+echo "B"
+if echo "C" && $dcr --no-deps --entrypoint python web --version | grep -q 'Python 2'; then
+echo "D";
   WARNING_TEXT="
  _  _   ____      ____  _       _______     ____  _____  _____  ____  _____   ______   _  _
 | || | |_  _|    |_  _|/ \     |_   __ \   |_   \|_   _||_   _||_   \|_   _|.' ___  | | || |
@@ -12,7 +15,9 @@ if docker-compose --no-ansi run --rm --no-deps --entrypoint python web --version
 (_)(_)      \/  \/|____| |____||____| |___||_____|\____||_____||_____|\____|\`._____.' (_)(_)
 
 "
+echo "E"
   echo "$WARNING_TEXT"
+echo "F"
   echo '-----------------------------------------------------------'
   echo 'You are using Sentry with Python 2, which is deprecated.'
   echo 'Sentry 21.1 will be the last version with Python 2 support.'


### PR DESCRIPTION
Removes the obsolete `echo ''` at the end, tries to make sure we see the warning on CI too.
