### PR TITLE
Improve on issue validation

### DIFF
--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -14,11 +14,7 @@ jobs:
       run: |
 
         # Trust users who belong to the getsentry org.
-        check_membership() {
-          gh api "https://api.github.com/orgs/getsentry/members/${{ github.actor }}" 2> /dev/null
-          return 0  # prevent GHA from exiting on non-zero return code from the previous line
-        }
-        if [ -z "$(check_membership)" ]; then
+        if gh api "https://api.github.com/orgs/getsentry/members/${{ github.actor }}" >/dev/null 2>&1; then
           echo "Skipping validation, because ${{ github.actor }} is a member of the getsentry org."
           exit 0
         else

--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -12,17 +12,17 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        # Trust users who belong to the getsentry org (id: 1396951). Due to API
-        # limitations, we can only see this if the user's membership is public.
-        sentry_org=$(
-          gh api "https://api.github.com/users/${{ github.actor }}/orgs" \
-            | jq '.[] | select(.id==1396951)'
-        )
-        if [ -z "$sentry_org" ]; then
-          echo "${{ github.actor }} is not a member of the getsentry org. 🧐"
-        else
+
+        # Trust users who belong to the getsentry org.
+        check_membership() {
+          gh api "https://api.github.com/orgs/getsentry/members/${{ github.actor }}" 2> /dev/null
+          return 0  # prevent GHA from exiting on non-zero return code from the previous line
+        }
+        if [ -z "$(check_membership)" ]; then
           echo "Skipping validation, because ${{ github.actor }} is a member of the getsentry org."
           exit 0
+        else
+          echo "${{ github.actor }} is not a member of the getsentry org. 🧐"
         fi
 
         # Look for a template where the headings match this issue's

--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -9,7 +9,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: "Validate issue against templates"
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
+        # Trust users who belong to the getsentry org (id: 1396951). Due to API
+        # limitations, we can only see this if the user's membership is public.
+        sentry_org=$(
+          gh api "https://api.github.com/users/${{ github.actor }}/orgs" \
+            | jq '.[] | select(.id==1396951)'
+        )
+        if [ -z "$sentry_org" ]; then
+          echo "${{ github.actor }} is not a member of the getsentry org. 🧐"
+        else
+          echo "Skipping validation, because ${{ github.actor }} is a member of the getsentry org."
+          exit 0
+        fi
+
         # Look for a template where the headings match this issue's
         echo "${{ github.event.issue.body }}" > issue-body
         for template in $(ls .github/ISSUE_TEMPLATE/*.md 2> /dev/null); do
@@ -24,7 +39,6 @@ jobs:
         done
 
         # Failed to find a match! Close the issue.
-        echo "${{ github.token }}" | gh auth login --with-token
         cat << EOF > comment
         {"body": "Sorry, friend. As far as this ol' bot can tell, your issue does not use one of this repo's available issue templates. Please [try again using a template](https://github.com/${{ github.repository }}/issues/new/choose) so that we have the best chance of understanding and addressing your issue. (And if I'm confused, please [let us know](https://github.com/getsentry/.github/issues/new?title=template+enforcer+is+confused&body=${{ github.event.issue.html_url }}). 😬)\n\n----\n\n[![Did you see the memo about this?](https://user-images.githubusercontent.com/134455/104515469-e04a9c80-55c0-11eb-8e15-ffe9c0b8dd7f.gif)](https://www.youtube.com/watch?v=Fy3rjQGc6lA)"}
         EOF

--- a/.github/workflows/validate-new-issue.yml
+++ b/.github/workflows/validate-new-issue.yml
@@ -44,7 +44,9 @@ jobs:
         EOF
 
         # Might get `gh issue comment` some day - https://github.com/cli/cli/issues/517
+        echo -n "Commented: "
         gh api "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
           --method POST \
-          --input comment
+          --input comment \
+          | jq .html_url
         gh issue close ${{ github.event.issue.number }}


### PR DESCRIPTION
https://github.com/getsentry/.github/issues/8

- Use envvar for authentication (better place for secrets).
- Skip validation for staff (less noise when we go to `sentry`).
- Link to "closing" comment at the end.