### PR TITLE
ci: Increase pool size to prevent pool closed errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install and test
         env:
-          COMPOSE_PARALLEL_LIMIT: 50
+          COMPOSE_PARALLEL_LIMIT: 100
           COMPOSE_HTTP_TIMEOUT: 450
           SENTRY_PYTHON2: ${{ matrix.py2 == '1' || '' }}
         run: |


### PR DESCRIPTION
Based on my reading, this error comes from urllib3.

https://urllib3.readthedocs.io/en/latest/advanced-usage.html
>The behavior of the pooling for ConnectionPool is different from PoolManager. By default, if a new request is made and there is no free connection in the pool then a new connection will be created. However, this connection will not be saved if more than maxsize connections exist. This means that maxsize does not determine the maximum number of connections that can be open to a particular host, just the maximum number of connections to keep in the pool.

I think the ideal solution would be to add `retry` and `block` options to [docker-py](https://github.com/docker/docker-py/blob/ce2669e3edfe5d3215ba501cc9771fc0ffad680a/docker/transport/unixconn.py#L58-L70) but that's a long shot.
