### PR TITLE
ci(release): Make sure to pull before pushing in post-release

### DIFF
--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -7,4 +7,4 @@ cd $SCRIPT_DIR/..
 # Bring master back to nightlies after merge from release branch
 
 SYMBOLICATOR_VERSION=nightly ./scripts/bump-version.sh '' 'nightly'
-git diff --quiet || git commit -anm 'build: Set master version to nightly' && git push
+git diff --quiet || git commit -anm 'build: Set master version to nightly' && git pull --rebase && git push


### PR DESCRIPTION
Fixes the issue we had over at getsentry/publish#60. This aligns the script with [the one at getsentry/sentry](https://github.com/getsentry/sentry/blob/master/scripts/post-release.sh#L6)
