### PR TITLE
ci(test): Fix 'pool is closed' errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Install and test
         env:
-          COMPOSE_PARALLEL_LIMIT: 200
-          COMPOSE_HTTP_TIMEOUT: 450
           SENTRY_PYTHON2: ${{ matrix.py2 == '1' || '' }}
         run: |
           ./install.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ defaults:
 jobs:
   test:
     strategy:
-      # Only run one job at a time as they are quite demanding
-      max-parallel: 1
       matrix:
         py2: ["", "1"]
     runs-on: ubuntu-18.04

--- a/install.sh
+++ b/install.sh
@@ -226,7 +226,7 @@ echo "Building and tagging Docker images..."
 echo ""
 # Build the sentry onpremise image first as it is needed for the cron image
 $dc build --force-rm web
-$dc build --force-rm --parallel
+$dc build --force-rm
 echo ""
 echo "Docker images built."
 


### PR DESCRIPTION
Fixes #823. In `install.sh` we build a local sentry image that is used by many services from using the build context under the `./sentry` directory. To avoid building this image multiple times, we also give it a specific name which is referred from multiple services. The issue is, we also run `docker-compose build --parallel` which creates a race condition when building this image as `docker-compose` doesn't check whether the image is already there or not. This is the root cause of all these random failures: an unsurprising race condition.
