### PR TITLE
fix(nginx): Remove X-Real-IP header entry

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,7 +44,6 @@ http {
 	# it could be "close" to close a keepalive connection
 	proxy_set_header Connection '';
 	proxy_set_header Host $host;
-	proxy_set_header X-Real-IP "";
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
 	proxy_set_header X-Request-Id $request_id;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,7 +44,7 @@ http {
 	# it could be "close" to close a keepalive connection
 	proxy_set_header Connection '';
 	proxy_set_header Host $host;
-	proxy_set_header X-Real-IP $remote_addr;
+	proxy_set_header X-Real-IP "";
 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	proxy_set_header X-Forwarded-Proto $scheme;
 	proxy_set_header X-Request-Id $request_id;


### PR DESCRIPTION
Removes the obsolete and confusing `X-Real-IP` header setting from the Nginx config.