### PR TITLE
docs: Add 20 GB minimum disk space requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docke
  * Docker 19.03.6+
  * Compose 1.24.1+
  * 8 GB RAM
+ * 20 GB Free Disk Space
 
 ## Setup
 


### PR DESCRIPTION
When trying to install self-hosted Sentry on Google Cloud Compute container-optimized OS, I hit an issue where the disk space was not sufficient to even build local images. Given Kafka and Clickhouse are also quite disk-intensive, it makes sense to add this to the docs.

Opted not to add an automated check for this as it is not easy to determine the path Sentry installation will consume, hence the free space there.
