### PR TITLE
fix(config): extended-permissions is on github-login, not app

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -76,7 +76,7 @@ transaction-events.force-disable-internal-project: true
 # GitHub Integration #
 ######################
 
-# github-app.extended-permissions: ['repo']
+# github-login.extended-permissions: ['repo']
 # github-app.id: GITHUB_APP_ID
 # github-app.name: 'GITHUB_APP_NAME'
 # github-app.webhook-secret: 'GITHUB_WEBHOOK_SECRET' # Use only if configured in GitHub


### PR DESCRIPTION
Fixes the issue where we set an invalid option, `github-app.extended-permissions`, instead of the correct one, `github-login.extended-permissions`. Some people mentioned this warning earlier but never clearly enough to point that it was coming from our default settings suggestions.
