### PR TITLE
fix(deps): Add missing snuba consumer dependencies to Sentry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ x-sentry-defaults: &sentry_defaults
     - snuba-outcomes-consumer
     - snuba-sessions-consumer
     - snuba-transactions-consumer
+    - snuba-subscription-consumer-events
+    - snuba-subscription-consumer-transactions
     - snuba-replacer
     - symbolicator
     - kafka


### PR DESCRIPTION
These were looked over when they were added. This is not a big deal as running `docker-compose up -d` spins up all services but this fix is for correctness sake, especially for folks using this repo as a basis for more complex setups.
