### PR TITLE
fix(relay): Remove http._client usage

### DIFF
--- a/relay/config.example.yml
+++ b/relay/config.example.yml
@@ -11,5 +11,3 @@ processing:
     - {name: "message.max.bytes", value: 50000000} #50MB or bust
   redis: redis://redis:6379
   geoip_path: "/geoip/GeoLite2-City.mmdb"
-http:
-  _client: "reqwest"


### PR DESCRIPTION
As per https://github.com/getsentry/relay/pull/938 this option no longer
exists. Existing values will be ignored, however.