### PR TITLE
fix(release): Fix post-release script so it operates on master

### DIFF
--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -5,6 +5,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR/..
 
 # Bring master back to nightlies after merge from release branch
-
+git checkout master && git pull
 SYMBOLICATOR_VERSION=nightly ./scripts/bump-version.sh '' 'nightly'
 git diff --quiet || git commit -anm 'build: Set master version to nightly' && git pull --rebase && git push


### PR DESCRIPTION
We've been leaving onpremise master with the latest release, instead of nightly builds for 2 releases now. Even if the post-release script runs, it bumped the versions to nightly on the release branch, making it effectively a no-op. This should be addressed in Craft via getsentry/craft#115 but until then, we need this extra line.
