### PR TITLE
Clean up the refactor

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ fi
 log_file="sentry_install_log-`date +'%Y-%m-%d_%H-%M-%S'`.txt"
 exec &> >(tee -a "$log_file")
 
-source ./install/_lib.sh
+source "$(dirname $0)/install/_lib.sh"
 
 echo "${_group}Defining variables and helpers ..."
 MIN_DOCKER_VERSION='19.03.6'
@@ -139,7 +139,7 @@ if [[ "$IS_KVM" -eq 0 ]]; then
 fi
 echo "${_endgroup}"
 
-./install/create-docker-volumes.sh
+source ./install/create-docker-volumes.sh
 
 echo "${_group}Ensuring files from examples ..."
 ensure_file_from_example $SENTRY_CONFIG_PY
@@ -265,14 +265,14 @@ for topic in $NEEDED_KAFKA_TOPICS; do
 done
 echo "${_endgroup}"
 
-./install/upgrade-postgres.sh
-./install/set-up-and-migrate-database.sh
-./install/migrate-file-storage.sh
-./install/relay-credentials.sh
-./install/geoip.sh
+source ./install/upgrade-postgres.sh
+source ./install/set-up-and-migrate-database.sh
+source ./install/migrate-file-storage.sh
+source ./install/relay-credentials.sh
+source ./install/geoip.sh
 
 if [[ "$MINIMIZE_DOWNTIME" ]]; then
-  ./install/restart-carefully.sh
+  source ./install/restart-carefully.sh
 else
   echo ""
   echo "-----------------------------------------------------------------"

--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
 set -euo pipefail
+test "${DEBUG:-}" && set -x
 
 # Work from the onpremise root, no matter which script is called from where.
 if [[ "$(basename $0)" = "install.sh" ]]; then
@@ -15,7 +15,7 @@ define_stuff() {
   # Read .env for default values with a tip o' the hat to https://stackoverflow.com/a/59831605/90297
   t=$(mktemp) && export -p > "$t" && set -a && . $_ENV && set +a && . "$t" && rm "$t" && unset t
 
-  if [ "${GITHUB_ACTIONS:-''}" = "true" ]; then
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
     _group="::group::"
     _endgroup="::endgroup::"
   else

--- a/install/_test_setup.sh
+++ b/install/_test_setup.sh
@@ -1,6 +1,5 @@
 set -euo pipefail
-test ${DEBUG:-''} && set -x
-cd "$(dirname $0)/.."
+source "$(dirname $0)/_lib.sh"
 
 rm -rf /tmp/sentry-onpremise-test-sandbox.*
 _SANDBOX="$(mktemp -d /tmp/sentry-onpremise-test-sandbox.XXX)"
@@ -10,7 +9,7 @@ report_success() {
 }
 
 teardown() {
-  test ${DEBUG:-''} || rm -rf "$_SANDBOX"
+  test "${DEBUG:-}" || rm -rf "$_SANDBOX"
 }
 
 setup() {

--- a/install/create-docker-volumes-test.sh
+++ b/install/create-docker-volumes-test.sh
@@ -11,9 +11,9 @@ count() {
 before=$(count)
 test $before -eq 0 || test $before -eq $expected
 
-./install/create-docker-volumes.sh
-./install/create-docker-volumes.sh
-./install/create-docker-volumes.sh
+source ./install/create-docker-volumes.sh
+source ./install/create-docker-volumes.sh
+source ./install/create-docker-volumes.sh
 
 test $(count) -eq $expected
 

--- a/install/create-docker-volumes.sh
+++ b/install/create-docker-volumes.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-source "$(dirname $0)/_lib.sh"
 echo "${_group}Creating volumes for persistent storage ..."
 
 echo "Created $(docker volume create --name=sentry-clickhouse)."

--- a/install/geoip-test.sh
+++ b/install/geoip-test.sh
@@ -5,12 +5,12 @@ mmdb="geoip/GeoLite2-City.mmdb"
 
 # Starts with no mmdb, ends up with empty.
 test ! -f $mmdb
-./install/geoip.sh
+source ./install/geoip.sh
 diff -rub $mmdb $mmdb.empty
 
 # Doesn't clobber existing, though.
 echo GARBAGE > $mmdb
-./install/geoip.sh
+source ./install/geoip.sh
 test "$(cat $mmdb)" = "GARBAGE"
 
 report_success

--- a/install/geoip.sh
+++ b/install/geoip.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-source "$(dirname $0)/_lib.sh"
 echo "${_group}Setting up GeoIP integration ..."
 
 install_geoip() {

--- a/install/migrate-file-storage.sh
+++ b/install/migrate-file-storage.sh
@@ -1,7 +1,5 @@
-#!/usr/bin/env bash
-source "$(dirname $0)/_lib.sh"
-
 echo "${_group}Migrating file storage ..."
+
 SENTRY_DATA_NEEDS_MIGRATION=$(docker run --rm -v sentry-data:/data alpine ash -c "[ ! -d '/data/files' ] && ls -A1x /data | wc -l || true")
 if [[ -n "$SENTRY_DATA_NEEDS_MIGRATION" ]]; then
   # Use the web (Sentry) image so the file owners are kept as sentry:sentry
@@ -9,4 +7,5 @@ if [[ -n "$SENTRY_DATA_NEEDS_MIGRATION" ]]; then
   $dcr --entrypoint \"/bin/bash\" web -c \
     "mkdir -p /tmp/files; mv /data/* /tmp/files/; mv /tmp/files /data/files; chown -R sentry:sentry /data"
 fi
+
 echo "${_endgroup}"

--- a/install/relay-credentials-test.sh
+++ b/install/relay-credentials-test.sh
@@ -9,7 +9,7 @@ test ! -f $cfg
 test ! -f $creds
 
 # Running the install script adds them.
-./install/relay-credentials.sh
+source ./install/relay-credentials.sh
 test -f $cfg
 test -f $creds
 test "$(jq -r 'keys[2]' $creds)" = "secret_key"
@@ -17,7 +17,7 @@ test "$(jq -r 'keys[2]' $creds)" = "secret_key"
 # If the files exist we don't touch it.
 echo GARBAGE > $cfg
 echo MOAR GARBAGE > $creds
-./install/relay-credentials.sh
+source ./install/relay-credentials.sh
 test "$(cat $cfg)" = "GARBAGE"
 test "$(cat $creds)" = "MOAR GARBAGE"
 

--- a/install/relay-credentials.sh
+++ b/install/relay-credentials.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-source "$(dirname $0)/_lib.sh"
 echo "${_group}Generating Relay credentials ..."
 
 RELAY_CONFIG_YML="relay/config.yml"

--- a/install/restart-carefully.sh
+++ b/install/restart-carefully.sh
@@ -1,7 +1,5 @@
-#!/usr/bin/env bash
-source "$(dirname $0)/_lib.sh"
-
 echo "${_group}Waiting for Sentry to start ..."
+
 # Start the whole setup, except nginx and relay.
 $dc up -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
 $dc exec -T nginx service nginx reload
@@ -11,4 +9,5 @@ docker run --rm --network="${COMPOSE_PROJECT_NAME}_default" alpine ash \
 
 # Make sure everything is up. This should only touch relay and nginx
 $dc up -d
+
 echo "${_endgroup}"

--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -1,8 +1,6 @@
-#!/usr/bin/env bash
-source "$(dirname $0)/_lib.sh"
-
 echo "${_group}Setting up / migrating database ..."
-if [[ -n "${CI:-''}" || "${SKIP_USER_PROMPT:-0}" == 1 ]]; then
+
+if [[ -n "${CI:-}" || "${SKIP_USER_PROMPT:-0}" == 1 ]]; then
   $dcr web upgrade --noinput
   echo ""
   echo "Did not prompt for user creation due to non-interactive shell."
@@ -13,4 +11,5 @@ if [[ -n "${CI:-''}" || "${SKIP_USER_PROMPT:-0}" == 1 ]]; then
 else
   $dcr web upgrade
 fi
+
 echo "${_endgroup}"

--- a/install/upgrade-postgres.sh
+++ b/install/upgrade-postgres.sh
@@ -1,7 +1,5 @@
-#!/usr/bin/env bash
-source "$(dirname $0)/_lib.sh"
-
 echo "${_group}Ensuring proper PostgreSQL version ..."
+
 # Very naively check whether there's an existing sentry-postgres volume and the PG version in it
 if [[ -n "$(docker volume ls -q --filter name=sentry-postgres)" && "$(docker run --rm -v sentry-postgres:/db busybox cat /db/PG_VERSION 2>/dev/null)" == "9.5" ]]; then
   docker volume rm sentry-postgres-new || true
@@ -22,4 +20,5 @@ if [[ -n "$(docker volume ls -q --filter name=sentry-postgres)" && "$(docker run
   # Finally, remove the new old volume as we are all in sentry-postgres now
   docker volume rm sentry-postgres-new
 fi
+
 echo "${_endgroup}"


### PR DESCRIPTION
- Use source appropriately (needed for config to propagate properly)
- Standardize group/endgroup line-spacing
- Clean up envvar defaults

Part of #795.