### PR TITLE
feat: Update storage target for Snuba consumer and replacer.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,7 @@ services:
   # Kafka consumer responsible for feeding events into Clickhouse
   snuba-consumer:
     <<: *snuba_defaults
-    command: consumer --storage events --auto-offset-reset=latest --max-batch-time-ms 750
+    command: consumer --storage errors --auto-offset-reset=latest --max-batch-time-ms 750
   # Kafka consumer responsible for feeding outcomes into Clickhouse
   # Use --auto-offset-reset=earliest to recover up to 7 days of TSDB data
   # since we did not do a proper migration
@@ -158,7 +158,7 @@ services:
     command: consumer --storage transactions --consumer-group transactions_group --auto-offset-reset=latest --max-batch-time-ms 750 --commit-log-topic=snuba-commit-log
   snuba-replacer:
     <<: *snuba_defaults
-    command: replacer --storage events --auto-offset-reset=latest --max-batch-size 3
+    command: replacer --storage errors --auto-offset-reset=latest --max-batch-size 3
   snuba-subscription-consumer-events:
     <<: *snuba_defaults
     command: subscriptions --auto-offset-reset=latest --consumer-group=snuba-events-subscriptions-consumers --topic=events --result-topic=events-subscription-results --dataset=events --commit-log-topic=snuba-commit-log --commit-log-group=snuba-consumers --delay-seconds=60 --schedule-ttl=60


### PR DESCRIPTION
This change ensures that the Snuba consumer and replacer start
to fill in the new table. It should be applied once we have
backfilled data and are ready to cut over to the new storage.

It should be part of the 21.4.0 release.

Depends on https://github.com/getsentry/snuba/pull/1801