### PR TITLE
ref(relay): Remove comment from sample config

### DIFF
--- a/relay/config.example.yml
+++ b/relay/config.example.yml
@@ -8,6 +8,6 @@ processing:
   enabled: true
   kafka_config:
     - {name: "bootstrap.servers", value: "kafka:9092"}
-    - {name: "message.max.bytes", value: 50000000}
+    - {name: "message.max.bytes", value: 50000000} # 50MB
   redis: redis://redis:6379
   geoip_path: "/geoip/GeoLite2-City.mmdb"

--- a/relay/config.example.yml
+++ b/relay/config.example.yml
@@ -8,6 +8,6 @@ processing:
   enabled: true
   kafka_config:
     - {name: "bootstrap.servers", value: "kafka:9092"}
-    - {name: "message.max.bytes", value: 50000000} #50MB or bust
+    - {name: "message.max.bytes", value: 50000000}
   redis: redis://redis:6379
   geoip_path: "/geoip/GeoLite2-City.mmdb"


### PR DESCRIPTION
This comment has unprofessional tone and does not serve any purpose. Since this is copied to every onpremise installation and I keep copying this code to public issue comments, it's better removed.