### PR TITLE
fix: Make relay depend on web for DNS resolution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,6 +259,7 @@ services:
     depends_on:
       - kafka
       - redis
+      - web
 volumes:
   sentry-data:
     external: true


### PR DESCRIPTION
This is a stop-gap solution to #918 until we figure out the negative DNS caching issue inside `relay`. This may also be due to Docker Compose making some assumptions/optimizations/limiting regarding cross-container access unless they are explicitly linked via the `depends_on` key.
