### PR TITLE
feat(cdc): Prepare the self hosted environment for the Change Data Capture pipeline

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,4 @@ SENTRY_IMAGE=getsentry/sentry:nightly
 SNUBA_IMAGE=getsentry/snuba:nightly
 RELAY_IMAGE=getsentry/relay:nightly
 SYMBOLICATOR_IMAGE=getsentry/symbolicator:nightly
+WAL2JSON_VERSION=latest

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ symbolicator/config.yml
 geoip/GeoIP.conf
 geoip/*.mmdb
 geoip/.geoipupdate.lock
+
+# wal2json download
+postgres/wal2json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,10 +71,27 @@ services:
   postgres:
     <<: *restart_policy
     image: "postgres:9.6"
+    command: 
+      - "postgres"
+      - "-c" 
+      - "wal_level=logical"
+      - "-c" 
+      - "max_replication_slots=1"
+      - "-c" 
+      - "max_wal_senders=1"
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
+    entrypoint: /cdc/postgres-entrypoint.sh
     volumes:
       - "sentry-postgres:/var/lib/postgresql/data"
+      - type: bind
+        read_only: true
+        source: ./postgres/init_hba.sh
+        target: /docker-entrypoint-initdb.d/init_hba.sh
+      - type: bind
+        read_only: true
+        source: ./postgres/postgres-entrypoint.sh
+        target: /cdc/postgres-entrypoint.sh
   zookeeper:
     <<: *restart_policy
     image: "confluentinc/cp-zookeeper:5.5.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,10 @@ services:
         read_only: true
         source: ./postgres/postgres-entrypoint.sh
         target: /cdc/postgres-entrypoint.sh
+      - type: bind
+        read_only: true
+        source: ./postgres/wal2json/wal2json.so
+        target: /wal2json/wal2json.so
   zookeeper:
     <<: *restart_policy
     image: "confluentinc/cp-zookeeper:5.5.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,31 +71,16 @@ services:
   postgres:
     <<: *restart_policy
     image: "postgres:9.6"
-    command: 
-      - "postgres"
-      - "-c" 
-      - "wal_level=logical"
-      - "-c" 
-      - "max_replication_slots=1"
-      - "-c" 
-      - "max_wal_senders=1"
+    command: ["postgres", "-c", "wal_level=logical", "-c", "max_replication_slots=1", "-c", "max_wal_senders=1"]
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
-    entrypoint: /cdc/postgres-entrypoint.sh
+    entrypoint: /opt/sentry/postgres-entrypoint.sh
     volumes:
       - "sentry-postgres:/var/lib/postgresql/data"
       - type: bind
         read_only: true
-        source: ./postgres/init_hba.sh
-        target: /docker-entrypoint-initdb.d/init_hba.sh
-      - type: bind
-        read_only: true
-        source: ./postgres/postgres-entrypoint.sh
-        target: /cdc/postgres-entrypoint.sh
-      - type: bind
-        read_only: true
-        source: ./postgres/wal2json/wal2json.so
-        target: /wal2json/wal2json.so
+        source: ./postgres/
+        target: /opt/sentry/
   zookeeper:
     <<: *restart_policy
     image: "confluentinc/cp-zookeeper:5.5.0"

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ source update-docker-images.sh
 source build-docker-images.sh
 source turn-things-off.sh
 source set-up-zookeeper.sh
+source install-wal2json.sh
 source bootstrap-snuba.sh
 source create-kafka-topics.sh
 source upgrade-postgres.sh

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -1,29 +1,31 @@
 echo "${_group}Downloading and installing wal2json ..."
 
-LATEST_VERSION_FILE="../postgres/wal2json/wal2json.so"
+VERSION_FILE="../postgres/wal2json/wal2json.so"
 ARCH=$(uname -m)
 FILE_NAME="wal2json-Linux-$ARCH.so"
-LATEST_VERSION=$(
-    wget "https://api.github.com/repos/getsentry/wal2json/releases/latest" -O - |
-    grep '"tag_name":' |
-    sed -E 's/.*"([^"]+)".*/\1/'
-)
 
-mkdir -p ../postgres/wal2json
-if [[ $LATEST_VERSION ]]; then
-    if [ ! -f "../postgres/wal2json/$LATEST_VERSION/$FILE_NAME" ]; then
-        mkdir -p "../postgres/wal2json/$LATEST_VERSION"
-        if wget \
-            "https://github.com/getsentry/wal2json/releases/download/$LATEST_VERSION/$FILE_NAME" \
-            -P "../postgres/wal2json/$LATEST_VERSION/"; then
-            ln -s "`pwd`/../postgres/wal2json/$LATEST_VERSION/$FILE_NAME" "$LATEST_VERSION_FILE"
-        fi
+if [[ $WAL2JSON_VERSION == "latest" ]]; then
+    VERSION=$(
+        wget "https://api.github.com/repos/getsentry/wal2json/releases/latest" -O - |
+        grep '"tag_name":' |
+        sed -E 's/.*"([^"]+)".*/\1/'
+    )
+
+    if [[ ! $VERSION ]]; then
+        echo "Cannot find wal2json latest version"
+        exit 1
     fi
 else
-    echo "wal2json is not installed and cannot download latest version"
-    exit 1
+    VERSION=$WAL2JSON_VERSION
 fi
 
-set -e
+mkdir -p ../postgres/wal2json
+if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
+    mkdir -p "../postgres/wal2json/$VERSION"
+    wget \
+        "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
+        -P "../postgres/wal2json/$VERSION/"; then
+    ln -s "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$VERSION_FILE"
+fi  
 
 echo "${_endgroup}"

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -1,0 +1,29 @@
+echo "${_group}Downloading and installing wal2json ..."
+
+LATEST_VERSION_FILE="../postgres/wal2json/wal2json.so"
+ARCH=$(uname -m)
+FILE_NAME="wal2json-Linux-$ARCH.so"
+LATEST_VERSION=$(
+    wget "https://api.github.com/repos/getsentry/wal2json/releases/latest" -O - |
+    grep '"tag_name":' |
+    sed -E 's/.*"([^"]+)".*/\1/'
+)
+
+mkdir -p ../postgres/wal2json
+if [[ $LATEST_VERSION ]]; then
+    if [ ! -f "../postgres/wal2json/$LATEST_VERSION/$FILE_NAME" ]; then
+        mkdir -p "../postgres/wal2json/$LATEST_VERSION"
+        if wget \
+            "https://github.com/getsentry/wal2json/releases/download/$LATEST_VERSION/$FILE_NAME" \
+            -P "../postgres/wal2json/$LATEST_VERSION/"; then
+            ln -s "`pwd`/../postgres/wal2json/$LATEST_VERSION/$FILE_NAME" "$LATEST_VERSION_FILE"
+        fi
+    fi
+else
+    echo "wal2json is not installed and cannot download latest version"
+    exit 1
+fi
+
+set -e
+
+echo "${_endgroup}"

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -25,9 +25,11 @@ fi
 mkdir -p ../postgres/wal2json
 if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     mkdir -p "../postgres/wal2json/$VERSION"
-    $DOCKER -v "`pwd`/../postgres/wal2json/$VERSION:/tmp" $CURL \
+    mkdir -p "/tmp/wal2json"
+    $DOCKER -v "/tmp/wal2json:/tmp" $CURL \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
         -o /tmp/$FILE_NAME
+    mv "/tmp/wal2json/$FILE_NAME" "../postgres/wal2json/$VERSION/$FILE_NAME"
     cp "../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
 fi  
 

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -25,7 +25,7 @@ if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     wget \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
         -P "../postgres/wal2json/$VERSION/"
-    ln -s "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
+    cp "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
 fi  
 
 echo "${_endgroup}"

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -2,7 +2,7 @@ echo "${_group}Downloading and installing wal2json ..."
 
 FILE_TO_USE="../postgres/wal2json/wal2json.so"
 ARCH=$(uname -m)
-FILE_NAME="wal2json-Linux-$ARCH.so"
+FILE_NAME="wal2json-Linux-$ARCH-glibc.so"
 
 DOCKER_CURL="docker run --rm curlimages/curl"
 

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -26,8 +26,9 @@ mkdir -p ../postgres/wal2json
 if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     mkdir -p "../postgres/wal2json/$VERSION"
     ls -al "../postgres/wal2json/"
+    id
     $DOCKER -v "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME:/tmp" \
-        $CURL \
+        $CURL -u $(id -u ${USER}):$(id -g ${USER})\
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
         -o /tmp/$FILE_NAME
     cp "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -28,7 +28,7 @@ if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
         > "../postgres/wal2json/$VERSION/$FILE_NAME"
         
-    cp "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
+    cp "../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
 fi  
 
 echo "${_endgroup}"

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -4,9 +4,12 @@ FILE_TO_USE="../postgres/wal2json/wal2json.so"
 ARCH=$(uname -m)
 FILE_NAME="wal2json-Linux-$ARCH.so"
 
+DOCKER="docker run --rm"
+CURL="curlimages/curl"
+
 if [[ $WAL2JSON_VERSION == "latest" ]]; then
     VERSION=$(
-        wget "https://api.github.com/repos/getsentry/wal2json/releases/latest" -O - |
+        $DOCKER $CURL https://api.github.com/repos/getsentry/wal2json/releases/latest |
         grep '"tag_name":' |
         sed -E 's/.*"([^"]+)".*/\1/'
     )
@@ -22,10 +25,10 @@ fi
 mkdir -p ../postgres/wal2json
 if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     mkdir -p "../postgres/wal2json/$VERSION"
-    wget \
+    $DOCKER -v "`pwd`/../postgres/wal2json/$VERSION:/tmp" $CURL \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
-        -P "../postgres/wal2json/$VERSION/"
-    cp "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
+        -o /tmp/$FILE_NAME
+    cp "../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
 fi  
 
 echo "${_endgroup}"

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -25,8 +25,9 @@ fi
 mkdir -p ../postgres/wal2json
 if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     mkdir -p "../postgres/wal2json/$VERSION"
+    ls -al "../postgres/wal2json/"
     $DOCKER -v "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME:/tmp" \
-        --user=`whoami` $CURL \
+        $CURL \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
         -o /tmp/$FILE_NAME
     cp "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -4,12 +4,11 @@ FILE_TO_USE="../postgres/wal2json/wal2json.so"
 ARCH=$(uname -m)
 FILE_NAME="wal2json-Linux-$ARCH.so"
 
-DOCKER="docker run --rm"
-CURL="curlimages/curl"
+DOCKER_CURL="docker run --rm curlimages/curl"
 
 if [[ $WAL2JSON_VERSION == "latest" ]]; then
     VERSION=$(
-        $DOCKER $CURL https://api.github.com/repos/getsentry/wal2json/releases/latest |
+        $DOCKER_CURL https://api.github.com/repos/getsentry/wal2json/releases/latest |
         grep '"tag_name":' |
         sed -E 's/.*"([^"]+)".*/\1/'
     )
@@ -25,12 +24,10 @@ fi
 mkdir -p ../postgres/wal2json
 if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     mkdir -p "../postgres/wal2json/$VERSION"
-    ls -al "../postgres/wal2json/"
-    id
-    $DOCKER -v "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME:/tmp" \
-        $CURL -u $(id -u ${USER}):$(id -g ${USER})\
+    $DOCKER_CURL -L \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
-        -o /tmp/$FILE_NAME
+        > "../postgres/wal2json/$VERSION/$FILE_NAME"
+        
     cp "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
 fi  
 

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -24,7 +24,7 @@ if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     mkdir -p "../postgres/wal2json/$VERSION"
     wget \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
-        -P "../postgres/wal2json/$VERSION/"; then
+        -P "../postgres/wal2json/$VERSION/"
     ln -s "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
 fi  
 

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -1,6 +1,6 @@
 echo "${_group}Downloading and installing wal2json ..."
 
-VERSION_FILE="../postgres/wal2json/wal2json.so"
+FILE_TO_USE="../postgres/wal2json/wal2json.so"
 ARCH=$(uname -m)
 FILE_NAME="wal2json-Linux-$ARCH.so"
 
@@ -25,7 +25,7 @@ if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     wget \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
         -P "../postgres/wal2json/$VERSION/"; then
-    ln -s "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$VERSION_FILE"
+    ln -s "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
 fi  
 
 echo "${_endgroup}"

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -25,12 +25,11 @@ fi
 mkdir -p ../postgres/wal2json
 if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     mkdir -p "../postgres/wal2json/$VERSION"
-    mkdir -p "/tmp/wal2json"
-    $DOCKER -v "/tmp/wal2json:/tmp" $CURL \
+    $DOCKER -v "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME:/tmp" \
+        --user=`whoami` $CURL \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
         -o /tmp/$FILE_NAME
-    mv "/tmp/wal2json/$FILE_NAME" "../postgres/wal2json/$VERSION/$FILE_NAME"
-    cp "../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
+    cp "`pwd`/../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
 fi  
 
 echo "${_endgroup}"

--- a/postgres/init_hba.sh
+++ b/postgres/init_hba.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Initializes the pg_hba file with access permissions to the replication
+# slots.
+
+set -e
+
+{ echo "host replication all all trust"; } >> "$PGDATA/pg_hba.conf"

--- a/postgres/postgres-entrypoint.sh
+++ b/postgres/postgres-entrypoint.sh
@@ -12,6 +12,10 @@
 
 set -e
 
+prep_init_db() {
+    cp /opt/sentry/init_hba.sh /docker-entrypoint-initdb.d/init_hba.sh
+}
+
 cdc_setup_hba_conf() {
     # Ensure pg-hba is properly configured to allow connections
     # to the replication slots.
@@ -23,17 +27,18 @@ cdc_setup_hba_conf() {
         echo "Replication config already present in pg_hba. Not changing anything."
     else
         # Execute the same script we run on DB initialization
-        /docker-entrypoint-initdb.d/init_hba.sh
+        /opt/sentry/init_hba.sh
     fi
 }
 
 bind_wal2json() {
-    # Create the symlink to wal2json.so
-    ln -sf /wal2json/wal2json.so `pg_config --pkglibdir`/wal2json.so
+    # Copy the file in the right place
+    cp /opt/sentry/wal2json/wal2json.so `pg_config --pkglibdir`/wal2json.so
 }
 
 echo "Setting up Change Data Capture"
 
+prep_init_db
 if [ "$1" = 'postgres' ]; then
     cdc_setup_hba_conf
     bind_wal2json

--- a/postgres/postgres-entrypoint.sh
+++ b/postgres/postgres-entrypoint.sh
@@ -27,10 +27,15 @@ cdc_setup_hba_conf() {
     fi
 }
 
+bind_wal2json() {
+    # Create the symlink to wal2json.so
+    ln -s /wal2json/wal2json.so `pg_config --pkglibdir`/wal2json.so
+}
 
 echo "Setting up Change Data Capture"
 
 if [ "$1" = 'postgres' ]; then
     cdc_setup_hba_conf
+    bind_wal2json
 fi
 exec /docker-entrypoint.sh "$@"

--- a/postgres/postgres-entrypoint.sh
+++ b/postgres/postgres-entrypoint.sh
@@ -29,7 +29,7 @@ cdc_setup_hba_conf() {
 
 bind_wal2json() {
     # Create the symlink to wal2json.so
-    ln -s /wal2json/wal2json.so `pg_config --pkglibdir`/wal2json.so
+    ln -sf /wal2json/wal2json.so `pg_config --pkglibdir`/wal2json.so
 }
 
 echo "Setting up Change Data Capture"

--- a/postgres/postgres-entrypoint.sh
+++ b/postgres/postgres-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This script replaces the default docker entrypoint for postgres in the
+# development environment.
+# Its job is to ensure postgres is properly configured to support the
+# Change Data Capture pipeline (by setting access permissions and installing
+# the replication plugin we use for CDC). Unfortunately the default
+# Postgres image does not allow this level of configurability so we need
+# to do it this way in order not to have to publish and maintain our own
+# Postgres image.
+#
+# This then, at the end, transfers control to the default entrypoint.
+
+set -e
+
+cdc_setup_hba_conf() {
+    # Ensure pg-hba is properly configured to allow connections
+    # to the replication slots.
+
+    PG_HBA="$PGDATA/pg_hba.conf"
+    if [ ! -f "$PG_HBA" ]; then
+        echo "DB not initialized. Postgres will take care of pg_hba"
+    elif [ "$(grep -c -E "^host\s+replication" "$PGDATA"/pg_hba.conf)" != 0 ]; then
+        echo "Replication config already present in pg_hba. Not changing anything."
+    else
+        # Execute the same script we run on DB initialization
+        /docker-entrypoint-initdb.d/init_hba.sh
+    fi
+}
+
+
+echo "Setting up Change Data Capture"
+
+if [ "$1" = 'postgres' ]; then
+    cdc_setup_hba_conf
+fi
+exec /docker-entrypoint.sh "$@"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -8,11 +8,14 @@ OLD_VERSION="$1"
 NEW_VERSION="$2"
 
 SYMBOLICATOR_VERSION=${SYMBOLICATOR_VERSION:-$(curl -s "https://api.github.com/repos/getsentry/symbolicator/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')}
+WAL2JSON_VERSION=${WAL2JSON_VERSION:-$(curl -s "https://api.github.com/repos/getsentry/wal2json/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')}
 
 sed -i -e "s/^SYMBOLICATOR_IMAGE=\([^:]\+\):.\+\$/SYMBOLICATOR_IMAGE=\1:$SYMBOLICATOR_VERSION/" .env
+sed -i -e "s/^WAL2JSON_VERSION=\([^:]\+\):.\+\$/WAL2JSON_VERSION=\1:$WAL2JSON_VERSION/" .env
 sed -i -e "s/^\(SENTRY\|SNUBA\|RELAY\)_IMAGE=\([^:]\+\):.\+\$/\1_IMAGE=\2:$NEW_VERSION/" .env
 sed -i -e "s/^\# Self-Hosted Sentry .*/# Self-Hosted Sentry $NEW_VERSION/" README.md
 sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
 
 echo "New version: $NEW_VERSION"
 echo "New Symbolicator version: $SYMBOLICATOR_VERSION"
+echo "New wal2json version: $WAL2JSON_VERSION"


### PR DESCRIPTION
This is an RFC on how to set up Change Data Capture.
We will use Change Data Capture to stream WAL updates from postgres into clickhouse so that features like issue search will be able to join event data and metadata (from postgres) through Snuba.

This requires the followings:
- A logical replicaiton plugin to be installed in postgres (https://github.com/getsentry/wal2json)
- A service to run that streams from the replication log to Kafka (https://github.com/getsentry/cdc)
- Datasets in Snuba.

This PR is preparing postgres to stream updates via the replication log.
The idea is to 
- download the the replication log plugin binary during install.sh
- mount a volume with the binary when starting postgres
- providing a new entrypoint to postgres that ensures everything is correctly configured.

There is a difference between how this is set up and how we do the same in the development environment.
In the development environment we download the library from the entrypoint itself and store it in a persistent volume, so we do not have to download it every time.
Unfortunately this does not work here as the postgres image is `postgres:9.6` while it is `postgres:9.6-alpine`. This one does not come with either wget or curl. I don't think installing that in the entrypoint would be a good idea, so the download happens in install.sh. I actually think this way is safer so we never depend on connectivity for postgres to start properly.

