### PR TITLE
fix(dcr): Explicitly disable TTY allocation

### DIFF
--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -26,7 +26,8 @@ else
 fi
 
 dc="docker-compose --no-ansi"
-dcr="$dc run --rm"
+dcri="$dc run --rm"
+dcr="$dcri -T"
 
 # A couple of the config files are referenced from other subscripts, so they
 # get vars, while multiple subscripts call ensure_file_from_example.

--- a/install/set-up-and-migrate-database.sh
+++ b/install/set-up-and-migrate-database.sh
@@ -9,7 +9,7 @@ if [[ -n "${CI:-}" || "${SKIP_USER_PROMPT:-0}" == 1 ]]; then
   echo "  docker-compose run --rm web createuser"
   echo ""
 else
-  $dcr web upgrade
+  $dcri web upgrade
 fi
 
 echo "${_endgroup}"


### PR DESCRIPTION
This should fix #959 by explicitly disabling TTY-allocation on `docker-compose run` invocations for non-interactive pieces.
