### PR TITLE
Comment out mail.host option in config.example.yml

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -8,7 +8,7 @@
 ###############
 
 # mail.backend: 'smtp'  # Use dummy if you want to disable email entirely
-mail.host: 'smtp'
+# mail.host: 'smtp'
 # mail.port: 25
 # mail.username: ''
 # mail.password: ''


### PR DESCRIPTION
The default mail.host option overrides the SMTP configuration during the initial setup and prevents the configured SMTP server from working. It should be commented out so the configuration done on the website is automatically used.

Fixes #965.