### PR TITLE
ref: Use alpine for nginx and upgrade nginx from 1.16 to 1.21

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,7 +272,7 @@ services:
     <<: *restart_policy
     ports:
       - "$SENTRY_BIND:80/tcp"
-    image: "nginx:1.16"
+    image: "nginx:1.21-alpine"
     volumes:
       - type: bind
         read_only: true

--- a/install/wrap-up.sh
+++ b/install/wrap-up.sh
@@ -3,7 +3,7 @@ if [[ "$MINIMIZE_DOWNTIME" ]]; then
 
   # Start the whole setup, except nginx and relay.
   $dc up -d --remove-orphans $($dc config --services | grep -v -E '^(nginx|relay)$')
-  $dc exec -T nginx service nginx reload
+  $dc restart nginx
 
   docker run --rm --network="${COMPOSE_PROJECT_NAME}_default" alpine ash \
     -c 'while [[ "$(wget -T 1 -q -O- http://web:9000/_health/)" != "ok" ]]; do sleep 0.5; done'


### PR DESCRIPTION
- ~~Use alpine for postgres~~
- Use alpine for nginx
- Upgrade nginx from 1.16 to 1.21

NOTE: I did not dare to change the version of clickhouse, but it could use `21.3.12-alpine` if you allow the version to be changed.
Since there is no comment on why the version is so much specific (`20.3.9.70`) and that the clickhouse changelogs are way to large and need expertise I did not change anything.

Possible upgrades:
- PostgreSQL
- memcached
- redis

Ref: #950 