### PR TITLE
fix(test): Export test script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,3 @@
 /.github export-ignore
 /.editorconfig export-ignore
 /.craft.yml export-ignore
-/test.sh export-ignore


### PR DESCRIPTION
Follow-up to #973. Restores exporting test.sh so that integration tests can use
it after downloading the release archive.

