### PR TITLE
Make a reset button

### DIFF
--- a/reset.sh
+++ b/reset.sh
@@ -25,7 +25,7 @@ confirm "☠️  Warning! 😳 This is highly destructive! 😱 Are you sure you
 echo "Okay ... good luck! 😰"
 
 # Hit the reset button.
-docker compose down --volumes --rmi local
+docker compose down --volumes --remove-orphans --rmi local
 
 # Remove any remaining (likely external) volumes with name matching '.*sentry.*'.
 for volume in $(docker volume list --format '{{ .Name }}' | grep sentry); do

--- a/reset.sh
+++ b/reset.sh
@@ -34,10 +34,15 @@ for volume in $(docker volume list --format '{{ .Name }}' | grep sentry); do
     || echo "Skipped volume: $volume"
 done
 
-# If we have a version (or other git ref) given, install it.
-ref="${1:-}"
-if [ -z "$ref" ]; then
+# If we have a version given, install it.
+
+# Note that arbitrary git refs won't work, because the *_IMAGE variables in
+# .env will almost certainly point to :latest. Release tags of onpremise are
+# generally the only refs where these component versions are pinned.
+
+version="${1:-}"
+if [ -z "$version" ]; then
   exit
 fi
-git checkout "$ref"
+git checkout "$version"
 exec ./install.sh

--- a/reset.sh
+++ b/reset.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # The purpose of this script is to make it easy to reset a local onpremise
-# install to a clean state, optionally installing a particular version/sha.
+# install to a clean state, optionally installing a particular version/ref.
 
 set -euo pipefail
 
@@ -34,7 +34,7 @@ for volume in $(docker volume list --format '{{ .Name }}' | grep sentry); do
     || echo "Skipped volume: $volume"
 done
 
-# If we have a version (or other sha) given, install it.
+# If we have a version (or other git ref) given, install it.
 ref="${1:-}"
 if [ -z "$ref" ]; then
   exit

--- a/reset.sh
+++ b/reset.sh
@@ -34,15 +34,16 @@ for volume in $(docker volume list --format '{{ .Name }}' | grep sentry); do
     || echo "Skipped volume: $volume"
 done
 
-# If we have a version given, install it.
+# If we have a version given, switch to it.
 
 # Note that arbitrary git refs won't work, because the *_IMAGE variables in
 # .env will almost certainly point to :latest. Release tags of onpremise are
 # generally the only refs where these component versions are pinned.
 
 version="${1:-}"
-if [ -z "$version" ]; then
-  exit
+if [ -n "$version" ]; then
+  git checkout "$version"
 fi
-git checkout "$version"
+
+# Install.
 exec ./install.sh

--- a/reset.sh
+++ b/reset.sh
@@ -46,8 +46,8 @@ echo "Okay ... good luck! 😰"
 # Hit the reset button.
 docker compose down --volumes --remove-orphans --rmi local
 
-# Remove any remaining (likely external) volumes with name matching '.*sentry.*'.
-for volume in $(docker volume list --format '{{ .Name }}' | grep sentry); do
+# Remove any remaining (likely external) volumes with name matching 'sentry-.*'.
+for volume in $(docker volume list --format '{{ .Name }}' | grep '^sentry-'); do
   docker volume remove $volume > /dev/null \
     && echo "Removed volume: $volume" \
     || echo "Skipped volume: $volume"

--- a/reset.sh
+++ b/reset.sh
@@ -20,6 +20,25 @@ function confirm () {
   fi
 }
 
+
+# If we have a version given, validate it.
+# ----------------------------------------
+# Note that arbitrary git refs won't work, because the *_IMAGE variables in
+# .env will almost certainly point to :latest. Tagged releases are generally
+# the only refs where these component versions are pinned, so enforce that
+# we're targeting a valid tag here. Do this early in order to fail fast.
+
+version="${1:-}"
+if [ -n "$version" ]; then
+  set +e
+  git rev-parse --verify --quiet "refs/tags/$version" > /dev/null
+  if [ $? -gt 0 ]; then
+    echo "Bad version: $version"
+    exit
+  fi
+  set -e
+fi
+
 # Make sure they mean it.
 confirm "☠️  Warning! 😳 This is highly destructive! 😱 Are you sure you wish to proceed?"
 echo "Okay ... good luck! 😰"
@@ -35,15 +54,7 @@ for volume in $(docker volume list --format '{{ .Name }}' | grep sentry); do
 done
 
 # If we have a version given, switch to it.
-# -----------------------------------------
-# Note that arbitrary git refs won't work, because the *_IMAGE variables in
-# .env will almost certainly point to :latest. Tagged releases are generally
-# the only refs where these component versions are pinned, so enforce that
-# we're targeting a valid tag here.
-
-version="${1:-}"
 if [ -n "$version" ]; then
-  git rev-parse --verify --quiet "refs/tags/$version" > /dev/null
   git checkout "$version"
 fi
 

--- a/reset.sh
+++ b/reset.sh
@@ -25,7 +25,7 @@ confirm "☠️  Warning! 😳 This is highly destructive! 😱 Are you sure you
 echo "Okay ... good luck! 😰"
 
 # Hit the reset button.
-docker compose down --volumes
+docker compose down --volumes --rmi local
 
 # Remove any remaining (likely external) volumes with name matching '.*sentry.*'.
 for volume in $(docker volume list --format '{{ .Name }}' | grep sentry); do

--- a/reset.sh
+++ b/reset.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# The purpose of this script is to make it easy to reset a local onpremise
+# install to a clean state, optionally installing a particular version/sha.
+
+set -euo pipefail
+
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
+
+cd "$(dirname $0)"
+
+
+function confirm () {
+  read -p "$1 [y/n] " confirmation
+  if [ "$confirmation" != "y" ]; then
+    echo "Canceled. 😅"
+    exit
+  fi
+}
+
+# Make sure they mean it.
+confirm "☠️  Warning! 😳 This is highly destructive! 😱 Are you sure you wish to proceed?"
+echo "Okay ... good luck! 😰"
+
+# Hit the reset button.
+docker compose down --volumes
+
+# Remove any remaining (likely external) volumes with name matching '.*sentry.*'.
+for volume in $(docker volume list --format '{{ .Name }}' | grep sentry); do
+  docker volume remove $volume > /dev/null \
+    && echo "Removed volume: $volume" \
+    || echo "Skipped volume: $volume"
+done
+
+# If we have a version (or other sha) given, install it.
+ref="${1:-}"
+if [ -z "$ref" ]; then
+  exit
+fi
+git checkout "$ref"
+exec ./install.sh

--- a/reset.sh
+++ b/reset.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # The purpose of this script is to make it easy to reset a local onpremise
-# install to a clean state, optionally installing a particular version/ref.
+# install to a clean state, optionally targeting a particular version.
 
 set -euo pipefail
 

--- a/reset.sh
+++ b/reset.sh
@@ -35,13 +35,15 @@ for volume in $(docker volume list --format '{{ .Name }}' | grep sentry); do
 done
 
 # If we have a version given, switch to it.
-
+# -----------------------------------------
 # Note that arbitrary git refs won't work, because the *_IMAGE variables in
-# .env will almost certainly point to :latest. Release tags of onpremise are
-# generally the only refs where these component versions are pinned.
+# .env will almost certainly point to :latest. Tagged releases are generally
+# the only refs where these component versions are pinned, so enforce that
+# we're targeting a valid tag here.
 
 version="${1:-}"
 if [ -n "$version" ]; then
+  git rev-parse --verify --quiet "refs/tags/$version" > /dev/null
   git checkout "$version"
 fi
 


### PR DESCRIPTION
The purpose of this script is to make it easy to reset a local onpremise install to a clean state, optionally installing a particular version/sha. This is helpful for testing out upgrade scenarios such as in https://github.com/getsentry/sentry/issues/26134.