### PR TITLE
Require version on bug form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,7 +8,7 @@ body:
       placeholder: 21.7.0 ← should look like this (check the footer)
       description: What version of self-hosted Sentry are you running?
     validations:
-      required: false
+      required: true
   - type: textarea
     id: repro
     attributes:


### PR DESCRIPTION
Follow-up to b30e7ef94b3e5a4cbe04ff5c9c3d92aff75f93f7. This is not required in `sentry` because most folks are on SaaS and we don't care about version for that.