### PR TITLE
fix(kafka): Get Confluent images back to 5.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
         target: /opt/sentry/
   zookeeper:
     <<: *restart_policy
-    image: "confluentinc/cp-zookeeper:6.2.0"
+    image: "confluentinc/cp-zookeeper:5.5.0"
     environment:
       ZOOKEEPER_CLIENT_PORT: "2181"
       CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
@@ -132,7 +132,7 @@ services:
     <<: *restart_policy
     depends_on:
       - zookeeper
-    image: "confluentinc/cp-kafka:6.2.0"
+    image: "confluentinc/cp-kafka:5.5.0"
     environment:
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
       KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"


### PR DESCRIPTION
Fixes #1009 by partially reverting #1002. We need to make a 21.6.2 release soon and I didn't have time to dig into why Kafka upgrades were failing so reverting for safety for now.
