### PR TITLE
fix(install) Make wal2json copy more robust

### DIFF
--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -27,8 +27,8 @@ if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     $DOCKER_CURL -L \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
         > "../postgres/wal2json/$VERSION/$FILE_NAME"
-        
-    cp "../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
-fi  
+fi
+cp "../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"
+
 
 echo "${_endgroup}"


### PR DESCRIPTION
There is a potential conrner case where we may end up with the wal2json library in the `postgres/wal2json/VERSION/file` but not in `postgres/wal2json/wal2json.so`.

Not sure exactly how likely this could be, but thechnically it is possible that the download succeeds and `cp "../postgres/wal2json/$VERSION/$FILE_NAME" "$FILE_TO_USE"` does not. The next attempt the copy would not be attempted.

This fix ensures the copy always happens