### PR TITLE
fix(wal2json): Respect http_proxy/https_proxy/no_proxy when installing

### DIFF
--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -4,11 +4,15 @@ FILE_TO_USE="../postgres/wal2json/wal2json.so"
 ARCH=$(uname -m)
 FILE_NAME="wal2json-Linux-$ARCH-glibc.so"
 
-DOCKER_CURL="docker run --rm curlimages/curl"
+docker_curl() {
+    # The environment variables can be specified in lower case or upper case.
+    # The lower case version has precedence. http_proxy is an exception as it is only available in lower case.
+    docker run --rm -e http_proxy -e https_proxy -e HTTPS_PROXY -e no_proxy -e NO_PROXY curlimages/curl "$@"
+}
 
 if [[ $WAL2JSON_VERSION == "latest" ]]; then
     VERSION=$(
-        $DOCKER_CURL https://api.github.com/repos/getsentry/wal2json/releases/latest |
+        docker_curl https://api.github.com/repos/getsentry/wal2json/releases/latest |
         grep '"tag_name":' |
         sed -E 's/.*"([^"]+)".*/\1/'
     )
@@ -24,7 +28,7 @@ fi
 mkdir -p ../postgres/wal2json
 if [ ! -f "../postgres/wal2json/$VERSION/$FILE_NAME" ]; then
     mkdir -p "../postgres/wal2json/$VERSION"
-    $DOCKER_CURL -L \
+    docker_curl -L \
         "https://github.com/getsentry/wal2json/releases/download/$VERSION/$FILE_NAME" \
         > "../postgres/wal2json/$VERSION/$FILE_NAME"
 fi


### PR DESCRIPTION
`http_proxy`, `https_proxy` and `no_proxy` environment variables should be forwarded to the curl container.