### PR TITLE
Add mail.use-ssl and mail.list-namespace in config.example.yml

### DIFF
--- a/sentry/config.example.yml
+++ b/sentry/config.example.yml
@@ -13,8 +13,14 @@ mail.host: 'smtp'
 # mail.username: ''
 # mail.password: ''
 # mail.use-tls: false
+# mail.use-ssl: false
 # The email address to send on behalf of
 # mail.from: 'root@localhost'
+
+# The mailing list namespace for emails sent by this Sentry server.
+# This should be a domain you own (often the same domain as the domain
+# part of the `mail.from` configuration parameter value) or `localhost`.
+# mail.list-namespace: 'localhost'
 
 # If you'd like to configure email replies, enable this.
 # mail.enable-replies: true


### PR DESCRIPTION
Cannot send emails after upgraded. After checking, I found that `mail.use-ssl` and `mail.list-namespace` must be set.
  
Add those to `config.example.yml`, make it easy to known.