### PR TITLE
fix: Fix `curl` image to version 7.77.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: Support custom CA roots ([#27062](https://github.com/getsentry/sentry/pull/27062)), see the [docs](https://develop.sentry.dev/self-hosted/custom-ca-roots/) for more details.
+- fix: Fix `curl` image to version 7.77.0
 
 ## 21.7.0
 

--- a/install/install-wal2json.sh
+++ b/install/install-wal2json.sh
@@ -7,7 +7,7 @@ FILE_NAME="wal2json-Linux-$ARCH-glibc.so"
 docker_curl() {
     # The environment variables can be specified in lower case or upper case.
     # The lower case version has precedence. http_proxy is an exception as it is only available in lower case.
-    docker run --rm -e http_proxy -e https_proxy -e HTTPS_PROXY -e no_proxy -e NO_PROXY curlimages/curl "$@"
+    docker run --rm -e http_proxy -e https_proxy -e HTTPS_PROXY -e no_proxy -e NO_PROXY curlimages/curl:7.77.0 "$@"
 }
 
 if [[ $WAL2JSON_VERSION == "latest" ]]; then


### PR DESCRIPTION
Turns out the latest, `7.78.0` may have issues with DNS resolution from time to time (I experienced this locally). It is also a good practice to fix it to a specific version.
