### PR TITLE
upgrade: use --ansi never for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Official bootstrap for running your own [Sentry](https://sentry.io/) with [Docke
 ## Requirements
 
 * Docker 19.03.6+
-* Compose 1.24.1+
+* Compose 1.28.0+
 * 4 CPU Cores
 * 8 GB RAM
 * 20 GB Free Disk Space

--- a/install/_lib.sh
+++ b/install/_lib.sh
@@ -25,7 +25,7 @@ else
   _endgroup=""
 fi
 
-dc="docker-compose --no-ansi"
+dc="docker-compose --ansi never"
 dcr="$dc run --rm"
 
 # A couple of the config files are referenced from other subscripts, so they

--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -1,7 +1,7 @@
 echo "${_group}Checking minimum requirements ..."
 
 MIN_DOCKER_VERSION='19.03.6'
-MIN_COMPOSE_VERSION='1.24.1'
+MIN_COMPOSE_VERSION='1.28.0'
 MIN_RAM_HARD=3800 # MB
 MIN_RAM_SOFT=7800 # MB
 MIN_CPU_HARD=2


### PR DESCRIPTION
Starting from `docker-compose` v1.28.0, the `--no-ansi` option is deprecated and a new, `--ansi never` option is introduced instead. This PR makes the deprecation warnings around this go away but bumps the minimum docker-compose version required to `1.28.0` as the older versions don't support the new option.
