### PR TITLE
fix(tests): Django 2.0 and 2.1 compatible csrf token extraction

### DIFF
--- a/_integration-test/run.sh
+++ b/_integration-test/run.sh
@@ -57,7 +57,7 @@ login () {
     exit -1
   fi
 
-  CSRF_TOKEN_FOR_LOGIN=$(curl $SENTRY_TEST_HOST -sL -c "$COOKIE_FILE" | awk -F "'" '
+  CSRF_TOKEN_FOR_LOGIN=$(curl $SENTRY_TEST_HOST -sL -c "$COOKIE_FILE" | awk -F "['\"]" '
     /csrfmiddlewaretoken/ {
     print $4 "=" $6;
     exit;


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/27555#issuecomment-893000179.

I also thought it would be more reliable to look for it in curl's cookiejar file, but it doesn't seem to be set.