### PR TITLE
Update check-minimum-requirements.sh

### DIFF
--- a/install/check-minimum-requirements.sh
+++ b/install/check-minimum-requirements.sh
@@ -1,7 +1,7 @@
 echo "${_group}Checking minimum requirements ..."
 
 MIN_DOCKER_VERSION='19.03.6'
-MIN_COMPOSE_VERSION='1.28.0'
+MIN_COMPOSE_VERSION='1.29.2'
 MIN_RAM_HARD=3800 # MB
 MIN_RAM_SOFT=7800 # MB
 MIN_CPU_HARD=2


### PR DESCRIPTION
Updatet minimum docker-compose version to 1.29.2.

I saw the new version 21.8 and just tried to update on my server. Unfortunately the **install.sh** script broke without a proper error message. Then I saw that the docker-compose version must be higher on the release, updated it on my server and the installer then ran through.
So that a proper error message should come here is my patch for the 21.8.0 .