### PR TITLE
fix(clickhouse): Use correct HTTP port for healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- fix(clickhouse): Use correct HTTP port for healthcheck (#1069)
+  Fixes the regular `Unexpected packet` errors in Clickhouse
+
 ## 21.8.0
 
 - feat: Support custom CA roots ([#27062](https://github.com/getsentry/sentry/pull/27062)), see the [docs](https://develop.sentry.dev/self-hosted/custom-ca-roots/) for more details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,7 +206,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget -nv -t1 --spider 'http://localhost:9000/' || exit 1",
+          "wget -nv -t1 --spider 'http://localhost:8123/' || exit 1",
         ]
       interval: 3s
       timeout: 600s


### PR DESCRIPTION
Should fix #1058
