### PR TITLE
fix(compose): Drop version from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 x-restart-policy: &restart_policy
   restart: unless-stopped
 x-depends_on-healthy: &depends_on-healthy


### PR DESCRIPTION
We've switched to using the [compose spec](https://github.com/compose-spec/compose-spec/blob/master/spec.md) with the recent upgrades and health-check related upgrades anyway so drop the incorrect and confusing compose file version.
