### PR TITLE
docs: simplify Linux `sudo` instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,23 +38,10 @@ Note that this may not work for all commit SHAs as this repository evolves with 
 
 ### Using Linux
 
-If you are using Linux and you need to use `sudo` when running `./install.sh`, modifying the version of Sentry is slightly different. First, run the following:
+If you are using Linux and you need to use `sudo` when running `./install.sh`, make sure to place the environment variable *after* `sudo`:
 
 ```shell
-sudo visudo
-```
-
-Then add the following line:
-
-```shell
-Defaults  env_keep += "SENTRY_IMAGE"
-```
-
-Save the file then in your terminal run the following
-
-```shell
-export SENTRY_IMAGE=us.gcr.io/sentryio/sentry:83b1380
-sudo ./install.sh
+sudo SENTRY_IMAGE=us.gcr.io/sentryio/sentry:83b1380 ./install.sh
 ```
 
 Where you replace `83b1380` with the sha you want to use.


### PR DESCRIPTION
Describe an easier way to pass the `SENTRY_IMAGE` environment variable to `install.sh` when using `sudo` that doesn't require modifying the `sudo` configuration.

### Demonstration

Simple test script:
```text
jnm@world$ cat > install.sh
#!/usr/bin/env bash
echo "It looks like you are $(whoami) and want to install $SENTRY_IMAGE"

jnm@world$ chmod +x install.sh
```

Basic environment variable test:
```text
jnm@world$ SENTRY_IMAGE=whee ./install.sh
It looks like you are jnm and want to install whee
```

Oops, `sudo` doesn't forward the variable from its own environment by default (#922):
```text
jnm@world$ SENTRY_IMAGE=whee sudo ./install.sh
[sudo] password for jnm:
It looks like you are root and want to install
```

However, there's an easier way than modifying the `sudo` configuration:
```text
jnm@world$ sudo SENTRY_IMAGE=whee ./install.sh
It looks like you are root and want to install whee
```

My environment is Ubuntu 20.04 (with the KDE neon desktop environment):
```text
jnm@world$ sudo --version
Sudo version 1.8.31
Sudoers policy plugin version 1.8.31
Sudoers file grammar version 46
Sudoers I/O plugin version 1.8.31

jnm@world$ lsb_release -a
No LSB modules are available.
Distributor ID: Neon
Description:    KDE neon User Edition 5.22
Release:        20.04
Codename:       focal
```

This method is also described in the same [StackOverflow discussion](https://stackoverflow.com/a/33183620/2402324) that was referenced by #922. Thanks for your consideration, and thanks for making Sentry available for on-premise installations!