### PR TITLE
Work around slow Kafka startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+x-restart-policy-slow: &restart_policy-slow
+  restart: always
 x-restart-policy: &restart_policy
   restart: unless-stopped
 x-depends_on-healthy: &depends_on-healthy
@@ -338,7 +340,7 @@ services:
       - web
       - relay
   relay:
-    <<: *restart_policy
+    <<: *restart_policy-slow
     image: "$RELAY_IMAGE"
     volumes:
       - type: bind


### PR DESCRIPTION
On some systems, Kafka takes a while to start up, which will error out the relay service. For whichever reason, this isn't handled by the dependencies expecting Kafka to be up before relay, which results in relay service failing and never restarting.

This sets the relay service to always restart until it finds Kafka. There should probably be a better workaround for that (an init script?).

Sample output of the relay service after not finding Kafka (`docker container logs project-relay_1`):

```
2021-10-11T15:04:45Z [r2d2] ERROR: failed to lookup address information: Temporary failure in name resolution
2021-10-11T15:04:46Z [relay_server::actors::upstream] ERROR: authentication encountered error: could not send request to upstream
  caused by: error sending request for url (http://web:9000/api/0/relays/register/challenge/): error trying to connect: tcp connect error: Connection refused (os error 111)
2021-10-11T15:04:46Z [relay_server::actors::upstream] ERROR: authentication encountered error: could not send request to upstream
  caused by: error sending request for url (http://web:9000/api/0/relays/register/challenge/): error trying to connect: tcp connect error: Connection refused (os error 111)
2021-10-11T15:04:47Z [relay_server::actors::upstream] ERROR: authentication encountered error: could not send request to upstream
  caused by: error sending request for url (http://web:9000/api/0/relays/register/challenge/): error trying to connect: tcp connect error: Connection refused (os error 111)
2021-10-11T15:04:48Z [rdkafka::client] ERROR: librdkafka: FAIL [thrd:kafka:9092/bootstrap]: kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 571ms in state CONNECT)
2021-10-11T15:04:48Z [rdkafka::client] ERROR: librdkafka: FAIL [thrd:kafka:9092/bootstrap]: kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 1017ms in state CONNECT)
2021-10-11T15:04:48Z [rdkafka::client] ERROR: librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 571ms in state CONNECT)
2021-10-11T15:04:48Z [rdkafka::client] ERROR: librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 1017ms in state CONNECT)
2021-10-11T15:04:48Z [rdkafka::client] ERROR: librdkafka: Global error: AllBrokersDown (Local: All broker connections are down): 1/1 brokers are down
2021-10-11T15:04:48Z [rdkafka::client] ERROR: librdkafka: FAIL [thrd:kafka:9092/bootstrap]: kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 0ms in state CONNECT, 1 identical error(s) suppressed)
2021-10-11T15:04:48Z [rdkafka::client] ERROR: librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 0ms in state CONNECT, 1 identical error(s) suppressed)
2021-10-11T15:04:48Z [relay_server::actors::upstream] ERROR: authentication encountered error: could not send request to upstream
  caused by: error sending request for url (http://web:9000/api/0/relays/register/challenge/): error trying to connect: tcp connect error: Connection refused (os error 111)
2021-10-11T15:04:49Z [rdkafka::client] ERROR: librdkafka: FAIL [thrd:kafka:9092/bootstrap]: kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 1ms in state CONNECT, 1 identical error(s) suppressed)
2021-10-11T15:04:49Z [rdkafka::client] ERROR: librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 1ms in state CONNECT, 1 identical error(s) suppressed)
2021-10-11T15:04:51Z [relay_server::actors::upstream] ERROR: authentication encountered error: could not send request to upstream
  caused by: error sending request for url (http://web:9000/api/0/relays/register/challenge/): error trying to connect: tcp connect error: Connection refused (os error 111)
2021-10-11T15:04:54Z [relay_server::actors::upstream] ERROR: authentication encountered error: could not send request to upstream
  caused by: error sending request for url (http://web:9000/api/0/relays/register/challenge/): error trying to connect: tcp connect error: Connection refused (os error 111)
2021-10-11T15:04:59Z [relay_server::actors::upstream] WARN: Network outage, scheduling another check in 0ns
2021-10-11T15:04:59Z [relay_server::actors::upstream] ERROR: authentication encountered error: could not send request to upstream
  caused by: error sending request for url (http://web:9000/api/0/relays/register/challenge/): error trying to connect: tcp connect error: Connection refused (os error 111)
2021-10-11T15:04:59Z [relay_server::actors::upstream] WARN: Network outage, scheduling another check in 1s
2021-10-11T15:05:00Z [relay_server::actors::upstream] WARN: Network outage, scheduling another check in 1.5s
2021-10-11T15:05:07Z [relay_server::actors::upstream] WARN: Network outage, scheduling another check in 2.25s
2021-10-11T15:05:18Z [rdkafka::client] ERROR: librdkafka: FAIL [thrd:kafka:9092/bootstrap]: kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 0ms in state CONNECT, 30 identical error(s) suppressed)
2021-10-11T15:05:18Z [rdkafka::client] ERROR: librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 0ms in state CONNECT, 30 identical error(s) suppressed)
2021-10-11T15:05:19Z [rdkafka::client] ERROR: librdkafka: FAIL [thrd:kafka:9092/bootstrap]: kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 0ms in state CONNECT, 29 identical error(s) suppressed)
2021-10-11T15:05:19Z [rdkafka::client] ERROR: librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/bootstrap: Connect to ipv4#172.20.0.25:9092 failed: Connection refused (after 0ms in state CONNECT, 29 identical error(s) suppressed)
```