### PR TITLE
Fix #1079 - bug in reset.sh

### DIFF
--- a/reset.sh
+++ b/reset.sh
@@ -59,4 +59,4 @@ if [ -n "$version" ]; then
 fi
 
 # Install.
-exec ./install.sh
+./install.sh


### PR DESCRIPTION
We need $0 to evaluate as install.sh in order for check-requirements to work.